### PR TITLE
Module options 2

### DIFF
--- a/docs/reference/api/pages.md
+++ b/docs/reference/api/pages.md
@@ -322,8 +322,6 @@ The successful `PUT` request returns the newly created document. See the [page d
 
 ## `PATCH /api/v1/@apostrophecms/page/:_id`
 
-The `PATCH`request may include *both* `_targetId` and `_position` as described in the [POST request description](#post-api-v1-apostrophecms-page). That is only required when moving the page.
-
 ### Query parameters
 
 | Parameter | Example | Description |
@@ -331,6 +329,8 @@ The `PATCH`request may include *both* `_targetId` and `_position` as described i
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to update a specific mode version of the page. |
 |`apos-locale` | `?apos-locale=fr` | Set to a valid locale to update the page document version for that locale. |
 <!-- TODO: link to docs about locales when available. -->
+
+If moving a page within the page tree, the `PATCH`request must include *both* `_targetId` and `_position` as described in the [POST request description](#post-api-v1-apostrophecms-page).
 
 If a `PATCH` operation is attempted in the published mode, the changes in the patch are applied to both the draft and the current document, but properties of the draft not mentioned in the patch are not published. This is to prevent unexpected outcomes.
 

--- a/docs/reference/api/pages.md
+++ b/docs/reference/api/pages.md
@@ -1,6 +1,6 @@
 # Page type REST endpoints
 
-All [page types](/reference/glossary.md#page) use a single set of API endpoints, unlike piece types. Difference in page type will primarily influence returned document properties based on the page type configurations.
+All [page types](/reference/glossary.md#page) use a single set of API endpoints, unlike piece types.
 
 ## Endpoints
 
@@ -10,8 +10,8 @@ All [page types](/reference/glossary.md#page) use a single set of API endpoints,
 
 | Method | Path | Description |
 |---------|---------|---------|
-|`GET` | [`/api/v1/@apostrophecms/page` ](#get-api-v1-apostrophecms-page)| Get the home page and all other pages structured in the home page's `_children` property |
-|`GET` | [`/api/v1/@apostrophecms/page/:_id`](#get-api-v1-apostrophecms-page-id) | Get a single page with a specified ID |
+|`GET` | [`/api/v1/@apostrophecms/page` ](#get-api-v1-apostrophecms-page)| Fetch the home page and all other pages structured in the home page's `_children` property |
+|`GET` | [`/api/v1/@apostrophecms/page/:_id`](#get-api-v1-apostrophecms-page-id) | Fetch a single page with a specified ID |
 |`POST` | [`/api/v1/@apostrophecms/page`](#post-api-v1-apostrophecms-page) | Insert a new page |
 |`PUT` | [`/api/v1/@apostrophecms/page/:_id`](#put-api-v1-apostrophecms-page-id) | Fully replace a specific page database document |
 |`PATCH` | [`/api/v1/@apostrophecms/page/:_id`](#patch-api-v1-apostrophecms-page-id) | Update only certain fields on a specific page |
@@ -322,7 +322,7 @@ The successful `PUT` request returns the newly created document. See the [page d
 
 ## `PATCH /api/v1/@apostrophecms/page/:_id`
 
-The `PATCH`request may include *both* `_targetId` and `_position` as described in the [POST request description](#post-api-v1-apostrophecms-page), but that is not required if the page is not being moved.
+The `PATCH`request may include *both* `_targetId` and `_position` as described in the [POST request description](#post-api-v1-apostrophecms-page). That is only required when moving the page.
 
 ### Query parameters
 

--- a/docs/reference/api/pages.md
+++ b/docs/reference/api/pages.md
@@ -1,33 +1,35 @@
 # Page type REST endpoints
 
-All [page types](#TODO) use a single set of API endpoints, unlike piece types. Difference in page type will primarily influence returned document properties based on the page type configurations.
+All [page types](/reference/glossary.md#page) use a single set of API endpoints, unlike piece types. Difference in page type will primarily influence returned document properties based on the page type configurations.
 
 ## Endpoints
 
+[Authentication](/reference/api/authentication.md) is required for all REST API requests.
+
 ### REST endpoints
 
-| Method | Path | Description | Auth required |
-|---------|---------|---------|---------|
-|GET | [`/api/v1/@apostrophecms/page` ](#get-api-v1-apostrophecms-page)| Get the home page and all other pages structured in the home page's `_children` property | FALSE |
-|GET | [`/api/v1/@apostrophecms/page/:_id`](#get-api-v1-apostrophecms-page-id) | Get a single page with a specified ID | FALSE |
-|POST | [`/api/v1/@apostrophecms/page`](#post-api-v1-apostrophecms-page) | Insert a new page | TRUE |
-|PUT | [`/api/v1/@apostrophecms/page/:_id`](#put-api-v1-apostrophecms-page-id) | Fully replace a specific page database document | TRUE |
-|PATCH | [`/api/v1/@apostrophecms/page/:_id`](#patch-api-v1-apostrophecms-page-id) | Update only certain fields on a specific page | TRUE |
-|DELETE | Not supported | [See more in PATCH request details.](#moving-pages-to-the-trash) | n/a |
+| Method | Path | Description |
+|---------|---------|---------|
+|GET | [`/api/v1/@apostrophecms/page` ](#get-api-v1-apostrophecms-page)| Get the home page and all other pages structured in the home page's `_children` property |
+|GET | [`/api/v1/@apostrophecms/page/:_id`](#get-api-v1-apostrophecms-page-id) | Get a single page with a specified ID |
+|POST | [`/api/v1/@apostrophecms/page`](#post-api-v1-apostrophecms-page) | Insert a new page |
+|PUT | [`/api/v1/@apostrophecms/page/:_id`](#put-api-v1-apostrophecms-page-id) | Fully replace a specific page database document |
+|PATCH | [`/api/v1/@apostrophecms/page/:_id`](#patch-api-v1-apostrophecms-page-id) | Update only certain fields on a specific page |
+|DELETE | Not supported | [See more in PATCH request details.](#moving-pages-to-the-trash) |
 
 ### Additional page endpoints
 
-| Method | Path | Description | Auth required |
+| Method | Path | Description |
 |---------|---------|---------|---------|
-|GET | [`/:_url?apos-refresh=1`](#get-url-apos-refresh-1) | Get a page's rendered content | FALSE |
-|POST | [`/api/v1/@apostrophecms/page/:_id/publish`](#post-api-v1-apostrophecms-page-id-publish) | Publish the draft version of a page | TRUE |
+|GET | [`/:_url?apos-refresh=1`](#get-url-apos-refresh-1) | Get a page's rendered content |
+|POST | [`/api/v1/@apostrophecms/page/:_id/publish`](#post-api-v1-apostrophecms-page-id-publish) | Publish the draft version of a page |
 
 <!-- TODOcument -->
-<!-- |GET | [`/api/v1/@apostrophecms/page/:_id?locales=1`](#get-api-v1-apostrophecms-page-id-locales-1) | Request the available locales for a specific page | TRUE |
-|POST | [`/api/v1/@apostrophecms/page/:_id/export`](#post-api-v1-apostrophecms-page-id-export) | Copy a page from one locale to another | TRUE |
-|POST | [`/api/v1/@apostrophecms/page/:_id/revert-draft-to-published`](#post-api-v1-apostrophecms-page-id-revert-draft-to-published) | Revert a draft page to the the state of the published version, if available | TRUE |
-|POST | [`/api/v1/@apostrophecms/page/:_id/revert-published-to-previous`](#post-api-v1-apostrophecms-page-id-revert-published-to-previous) | Revert a published page to the previous version, if available | TRUE |
-|POST | [`/api/v1/@apostrophecms/page/:_id/unpublish`](#post-api-v1-apostrophecms-page-id-unpublish) | Unpublish the published version of a page | TRUE | -->
+<!-- |GET | [`/api/v1/@apostrophecms/page/:_id?locales=1`](#get-api-v1-apostrophecms-page-id-locales-1) | Request the available locales for a specific page |
+|POST | [`/api/v1/@apostrophecms/page/:_id/export`](#post-api-v1-apostrophecms-page-id-export) | Copy a page from one locale to another |
+|POST | [`/api/v1/@apostrophecms/page/:_id/revert-draft-to-published`](#post-api-v1-apostrophecms-page-id-revert-draft-to-published) | Revert a draft page to the the state of the published version, if available |
+|POST | [`/api/v1/@apostrophecms/page/:_id/revert-published-to-previous`](#post-api-v1-apostrophecms-page-id-revert-published-to-previous) | Revert a published page to the previous version, if available |
+|POST | [`/api/v1/@apostrophecms/page/:_id/unpublish`](#post-api-v1-apostrophecms-page-id-unpublish) | Unpublish the published version of a page | -->
 
 ## `GET /api/v1/@apostrophecms/page`
 
@@ -39,7 +41,8 @@ All [page types](#TODO) use a single set of API endpoints, unlike piece types. D
 |`flat` | `?flat=1` | Set to `1` to [return page results in an flat array](#flat-array-response) instead of the page tree structure |
 |`children` | `?children=false` | Set to `false` to exclude the `_children` array` |
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` to request the draft version of page documents instead of the current published versions. Set to `published` or leave it off to get the published version. Authentication is required to get drafts. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to request page document versions for that locale. Defaults to the default locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request page document versions for that locale. Defaults to the default locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 ### Request example
 
@@ -205,7 +208,8 @@ Individual page objects will include `_children` and `_ancestor` arrays, as well
 | Parameter | Example | Description |
 |----------|------|-------------|
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to request a specific mode version of the page. Authentication is required to get drafts. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to request the page document version for that locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request the page document version for that locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 Read more about [mode and locale parameters on single-document requests](/guide/rest-apis.md#locale-and-mode-in-single-document-requests).
 
@@ -225,8 +229,6 @@ The successful GET request returns the matching document. See the [page document
 
 ## `POST /api/v1/@apostrophecms/page`
 
-**Authentication required.**
-
 ### Required properties
 
 | Property | Type | Description |
@@ -241,7 +243,8 @@ The `_position` property uses specific string values rather than index numbers t
 | Parameter | Example | Description |
 |----------|------|-------------|
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` to insert a page as a draft instead of immediately published. Set to `published` or leave it off to insert a published page. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to request page document versions for that locale. Defaults to the default locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request page document versions for that locale. Defaults to the default locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 ### Request example
 
@@ -270,8 +273,6 @@ The successful POST request returns the newly created document. See the [page do
 
 ## `PUT /api/v1/@apostrophecms/page/:_id`
 
-**Authentication required.**
-
 ### Required properties
 
 | Property | Type | Description |
@@ -286,8 +287,9 @@ The `_position` property uses specific string values rather than index numbers t
 | Parameter | Example | Description |
 |----------|------|-------------|
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to replace a specific mode version of the page. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to replace the page document version for that locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to replace the page document version for that locale. |
 |`render-areas` | `?render-areas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
+<!-- TODO: link to docs about locales when available. -->
 
 Read more about [mode and locale parameters on single-document requests](/guide/rest-apis.md#locale-and-mode-in-single-document-requests).
 
@@ -318,8 +320,6 @@ The successful PUT request returns the newly created document. See the [page doc
 
 ## `PATCH /api/v1/@apostrophecms/page/:_id`
 
-**Authentication required.**
-
 The PATCH request may include *both* `_targetId` and `_position` as described in the [POST request description](#post-api-v1-apostrophecms-page), but that is not required if the page is not being moved.
 
 ### Query parameters
@@ -327,7 +327,8 @@ The PATCH request may include *both* `_targetId` and `_position` as described in
 | Parameter | Example | Description |
 |----------|------|-------------|
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to update a specific mode version of the page. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to update the page document version for that locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to update the page document version for that locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 If a `PATCH` operation is attempted in the published mode, the changes in the patch are applied to both the draft and the current document, but properties of the draft not mentioned in the patch are not published. This is to prevent unexpected outcomes.
 
@@ -377,6 +378,8 @@ The trash is part of the overall page tree in order to maintain the nesting stru
 
 Including the `apos-refresh=1` query parameter value on an Apostrophe page URL returns the rendered HTML from the `refreshLayout.html` template, which excludes the wrapping markup from the `outerLayoutBase.html` template file outside of the `[data-apos-refreshable]` element. Apostrophe UI uses this parameter to refresh content during editing.
 
+Authentication is not required for this API route if `:_url` is a public URL.
+
 **We do not recommend making edits to `refreshLayout.html` for the sake of API requests as this template is critical to normal content editing.**
 <!-- TODO: Add and link to a how-to/guide/recipe about an alternative way to
 customize the response template (e.g., using a custom query param and looking
@@ -421,7 +424,8 @@ The `body` of the request is ignored.
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-locale` | `?apos-locale=fr` | Identify [a valid locale](#TODO) to publish the draft for that locale. Defaults to the locale of the `_id` in the request or the default locale. |
+|`apos-locale` | `?apos-locale=fr` | Identify a valid locale to publish the draft for that locale. Defaults to the locale of the `_id` in the request or the default locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 ### Request example
 

--- a/docs/reference/api/pieces.md
+++ b/docs/reference/api/pieces.md
@@ -1,6 +1,6 @@
 # Piece type REST endpoints
 
-Every [piece type](#TODO) has built in REST end points that share their overall structure in common. The exact document properties returned will depend on the piece type's fields.
+Every [piece type](/reference/glossary.md#piece) has built in REST end points that share their overall structure in common. The exact document properties returned will depend on the piece type's fields.
 
 ## Endpoints
 
@@ -8,20 +8,22 @@ Every [piece type](#TODO) has built in REST end points that share their overall 
 
 ### REST endpoints
 
-| Method | Path | Description | Auth required |
-|---------|---------|---------|---------|
-|GET | [`/api/v1/:piece-name`](#get-api-v1-piece-name)| Get all pieces of a given type, paginated| FALSE |
-|GET | [`/api/v1/:piece-name/:_id`](#get-api-v1-piece-name-id)| Get a single piece with a specified ID | FALSE |
-|POST | [`/api/v1/:piece-name`](#post-api-v1-piece-name)| Insert a new piece of the specified type | TRUE |
-|PUT | [`/api/v1/:piece-name/:_id`](#put-api-v1-piece-name-id)| Fully replace a specific piece document | TRUE |
-|PATCH | [`/api/v1/:piece-name/:_id`](#patch-api-v1-piece-name-id)| Update only certain fields on a specific document | TRUE |
-|DELETE | Not supported | Instead `PATCH` the `trash` property to `true` | n/a |
+[Authentication](/reference/api/authentication.md) is required for all requests other than `GET` requests for pieces with defined [`publicApiProjection`](/reference/module-options.md#publicapiprojection).
+
+| Method | Path | Description |
+|---------|---------|---------|
+|GET | [`/api/v1/:piece-name`](#get-api-v1-piece-name)| Get all pieces of a given type, paginated|
+|GET | [`/api/v1/:piece-name/:_id`](#get-api-v1-piece-name-id)| Get a single piece with a specified ID |
+|POST | [`/api/v1/:piece-name`](#post-api-v1-piece-name)| Insert a new piece of the specified type |
+|PUT | [`/api/v1/:piece-name/:_id`](#put-api-v1-piece-name-id)| Fully replace a specific piece document |
+|PATCH | [`/api/v1/:piece-name/:_id`](#patch-api-v1-piece-name-id)| Update only certain fields on a specific document |
+|DELETE | Not supported | Instead `PATCH` the `trash` property to `true` |
 
 ### Additional piece endpoints
 
-| Method | Path | Description | Auth required |
-|---------|---------|---------|---------|
-|POST | [`/api/v1/:piece-name/:_id/publish`](#post-api-v1-apostrophecms-piece-name-id-publish) | Publish the draft version of a piece | TRUE |
+| Method | Path | Description |
+|---------|---------|---------|
+|POST | [`/api/v1/:piece-name/:_id/publish`](#post-api-v1-piece-name-id-publish) | Publish the draft version of a piece |
 
 **This guide will use an `article` piece type as an example.** In addition to standard piece fields, this hypothetical piece type has the following fields (for the sake of illustration):
 - `author`: a `relationship` field connected to the `user` piece type
@@ -37,12 +39,14 @@ Every [piece type](#TODO) has built in REST end points that share their overall 
 |`page` | `?page=2` | The page of results to return |
 |`search` | `?search=shoes` | A search query to filter the response |
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` to request the draft version of piece documents instead of the current published versions. Set to `published` or leave it off to get the published version. Authentication is required to get drafts. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to request piece document versions for that locale. Defaults to the default locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request piece document versions for that locale. Defaults to the default locale. |
 |`render-areas` | `?render-areas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
+<!-- TODO: link to docs about locales when available. -->
 
 #### Custom filters
 
-You may configure custom filters for a piece type as well. See [the guide on custom filters for more information](#TODO).
+You may configure custom filters for a piece type as well. See [the guide on custom filters for more information](/guide/pieces.md#filters-are-also-configured-like-fields).
+<!-- TODO: Update the filters link when the new guide is written. -->
 
 ### Request example
 
@@ -96,8 +100,9 @@ On error an appropriate HTTP status code is returned.
 | Parameter | Example | Description |
 |----------|------|-------------|
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to request a specific mode version of the piece. Authentication is required to get drafts. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to request the piece document version for that locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request the piece document version for that locale. |
 |`render-areas` | `?render-areas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
+<!-- TODO: link to docs about locales when available. -->
 
 Read more about [mode and locale parameters on single-document requests](/guide/rest-apis.md#locale-and-mode-in-single-document-requests).
 
@@ -117,14 +122,13 @@ The successful GET request returns the matching document. See the [piece documen
 
 ## `POST /api/v1/:piece-name`
 
-**Authentication required.**
-
 ### Query parameters
 
 | Parameter | Example | Description |
 |----------|------|-------------|
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` to insert a piece as a draft instead of immediately published. Set to `published` or leave it off to insert a published piece. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to request piece document versions for that locale. Defaults to the default locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request piece document versions for that locale. Defaults to the default locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 ### Request example
 
@@ -148,14 +152,13 @@ The successful POST request returns the newly created document. See the [piece d
 
 ## `PUT /api/v1/:piece-name/:_id`
 
-**Authentication required.**
-
 ### Query parameters
 
 | Parameter | Example | Description |
 |----------|------|-------------|
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to replace a specific mode version of the piece. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to replace the piece document version for that locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to replace the piece document version for that locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 Read more about [mode and locale parameters on single-document requests](/guide/rest-apis.md#locale-and-mode-in-single-document-requests).
 
@@ -181,14 +184,13 @@ The successful PUT request returns the newly created document. See the [piece do
 
 ## `PATCH /api/v1/:piece-name/:_id`
 
-**Authentication required.**
-
 ### Query parameters
 
 | Parameter | Example | Description |
 |----------|------|-------------|
 |`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to update a specific mode version of the piece. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to update the piece document version for that locale. |
+|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to update the piece document version for that locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 If a `PATCH` operation is attempted in the published mode, the changes in the patch are applied to both the draft and the current document, but properties of the draft not mentioned in the patch are not published. This is to prevent unexpected outcomes.
 
@@ -234,7 +236,7 @@ The successful PATCH request returns the complete patched document. See the [pie
 
 Publish an existing `draft` mode document in a document set.
 
-The `:_id` segement of the route should be one of the following:
+The `:_id` segment of the route should be one of the following:
 - The `_id` property of the draft piece to be published
 - The `_id` property of the published piece to be replaced by the current `draft` version
 - The `aposDocId` property of the pieces in the document set
@@ -245,7 +247,8 @@ The `body` of the request is ignored.
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-locale` | `?apos-locale=fr` | Identify [a valid locale](#TODO) to publish the draft for that locale. Defaults to the locale of the `_id` in the request or the default locale. |
+|`apos-locale` | `?apos-locale=fr` | Identify a valid locale to publish the draft for that locale. Defaults to the locale of the `_id` in the request or the default locale. |
+<!-- TODO: link to docs about locales when available. -->
 
 ### Request example
 

--- a/docs/reference/api/pieces.md
+++ b/docs/reference/api/pieces.md
@@ -1,6 +1,6 @@
 # Piece type REST endpoints
 
-Every [piece type](/reference/glossary.md#piece) has built in REST end points that share their overall structure in common. The exact document properties returned will depend on the piece type's fields.
+Apostrophe provides built-in REST end points for all [piece types](/reference/glossary.md#piece). The exact document properties returned will depend on the piece type's fields.
 
 ## Endpoints
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -49,10 +49,10 @@ There is a single doc with the slug, `global`, which is always loaded and availa
 
 The slug of an Apostrophe doc is a string that uniquely identifies that doc within the database. Apostrophe will enforce that no two docs may have the same slug. Unlike the `_id` property of the database document, slugs _can_ change, however. Apostrophe user interface and REST API will suggest slugs automatically based on the document's title on creation.
 
-If the doc has a dedicated page (or [show page](#show-page) for a piece), the slug is used as a component of the page URL. This works differently for pages and pieces.
+If the doc is a page, or a piece with a [show page](#show-page), the slug is used as a component of the page URL. This works differently for pages and pieces.
 
 - [Page](#page) slugs begin with a forward slash and, by default, include sections for their parent pages, e.g., `/previous-page/new-page` for a page titled "New Page" with a parent page of "Previous Page." Editing a page slug will not effect the actual page tree structure, however.
-- [Piece](#piece) slugs do not begin with a forward slash nor do they include reference to an [index page](#index-page). A piece titled "New Piece," will get the suggested slug of `new-piece` if no other doc has that slug already.
+- [Piece](#piece) slugs do not begin with a forward slash nor do they include reference to an [index page](#index-page). A piece titled "New Piece" will get the suggested slug of `new-piece` if no other doc has that slug already.
 
 ## Widget
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -14,7 +14,7 @@ Modules created at project level live in subdirectories of `/modules`. For examp
 
 A "doc" refers to a content-related document in Apostrophe's database. They are in the `aposDocs` MongoDB collection.
 
-Docs contain various properties, including [areas](#area), as described by a schema configured for their **document types**. Each doc type will extend `@apostrophecms/piece-type`, `@apostrophecms/page-type`, `@apostrophecms/piece-page-type`, or another doc type that itself extends one of those core modules.
+Docs contain various properties, including [areas](#area), as described by a schema configured for their **document types** (or "doc type"). Each doc type will extend `@apostrophecms/piece-type`, `@apostrophecms/page-type`, `@apostrophecms/piece-page-type`, or another doc type that itself extends one of those core modules.
 
 At a minimum, a doc has unique `_id` and `slug` properties. The `type` property identifies the doc type and determines what other behaviors it might have. The `@apostrophecms/doc` module provides methods for working with docs, including the `apos.docs.getManager(doc.type)` method, which returns a reference to the module suited to working with that type of document.
 
@@ -44,6 +44,15 @@ Show page templates (`show.html`), do have access to their parent index page's `
 ## Global doc
 
 There is a single doc with the slug, `global`, which is always loaded and available to page templates as `data.global`. This is useful for shared, site-wide headers and footers that are editable, etc. It is managed by the `@apostrophecms/global` module.
+
+## Slug
+
+The slug of an Apostrophe doc is a string that uniquely identifies that doc within the database. Apostrophe will enforce that no two docs may have the same slug. Unlike the `_id` property of the database document, slugs _can_ change, however. Apostrophe user interface and REST API will suggest slugs automatically based on the document's title on creation.
+
+If the doc has a dedicated page (or [show page](#show-page) for a piece), the slug is used as a component of the page URL. This works differently for pages and pieces.
+
+- [Page](#page) slugs begin with a forward slash and, by default, include sections for their parent pages, e.g., `/previous-page/new-page` for a page titled "New Page" with a parent page of "Previous Page." Editing a page slug will not effect the actual page tree structure, however.
+- [Piece](#piece) slugs do not begin with a forward slash nor do they include reference to an [index page](#index-page). A piece titled "New Piece," will get the suggested slug of `new-piece` if no other doc has that slug already.
 
 ## Widget
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -47,11 +47,11 @@ There is a single doc with the slug, `global`, which is always loaded and availa
 
 ## Slug
 
-The slug of an Apostrophe doc is a string that uniquely identifies that doc within the database. Apostrophe will enforce that no two docs may have the same slug. Unlike the `_id` property of the database document, slugs _can_ change, however. Apostrophe user interface and REST API will suggest slugs automatically based on the document's title on creation.
+The slug of an Apostrophe doc is a string that uniquely identifies that doc within the database. Apostrophe will enforce that no two docs have the same slug. Slugs _can_ be changed, unlike the `_id` property of the database document. The Apostrophe user interface and REST API will suggest slugs automatically based on the document's title on creation.
 
 If the doc is a page, or a piece with a [show page](#show-page), the slug is used as a component of the page URL. This works differently for pages and pieces.
 
-- [Page](#page) slugs begin with a forward slash and, by default, include sections for their parent pages, e.g., `/previous-page/new-page` for a page titled "New Page" with a parent page of "Previous Page." Editing a page slug will not effect the actual page tree structure, however.
+- [Page](#page) slugs begin with a forward slash and, by default, include sections for their parent pages, e.g., `/previous-page/new-page` for a page titled "New Page" with a parent page of "Previous Page." Editing a page slug will not effect the actual page tree structure.
 - [Piece](#piece) slugs do not begin with a forward slash nor do they include reference to an [index page](#index-page). A piece titled "New Piece" will get the suggested slug of `new-piece` if no other doc has that slug already.
 
 ## Widget

--- a/docs/reference/module-options.md
+++ b/docs/reference/module-options.md
@@ -231,7 +231,7 @@ module.exports = {
 
 ### `sort`
 
-The `sort` option for a doc type defines a sorting order for requests to the database for that type. This setting generally follows the [MongoDB `$sort` aggregation](https://docs.mongodb.com/manual/reference/operator/aggregation/sort/) syntax. The option is set to an object containing field name keys with `1` as a property value for ascending order and `-1` for descending order.
+The `sort` option for a doc type defines a sorting order for requests to the database for that type. The option is set to an object containing field name keys with `1` as a property value for ascending order and `-1` for descending order.
 
 The default sort for all doc types is `{ updatedAt: -1 }`, meaning it returns documents based on the `updatedAt` property (the date and time of the last update) in descending order. The `sort` object can have multiple keys for more specific sorting.
 
@@ -265,7 +265,7 @@ module.exports = {
 
 ### `slugPrefix`
 
-Set `slugPrefix` to a string to prepend all [slugs](glossary.md#slug) for docs of this type. This can be useful to help prevent slugs, which must be unique for each doc in the database, from being reserved in some cases. For example, Apostrophe image docs have the `slugPrefix` value of `'image-'` so images, which do not typically have public pages, do not accidentally reserve a more reader-friendly slug.
+Set `slugPrefix` to a string to prepend all [slugs](glossary.md#slug) for docs of this type. This can prevent slugs, which must be unique to each doc, from being reserved in some cases. For example, Apostrophe image docs have the `slugPrefix` value of `'image-'` so images, which do not typically have public pages, do not accidentally reserve a more reader-friendly slug.
 
 #### Example
 
@@ -292,7 +292,7 @@ Option settings in this section apply to all piece modules (those that extend `@
 
 ### `pluralLabel`
 
-Similar to `label` for all doc types, the `pluraLabel` option sets the string the user interface will use to describe a piece type in plural contexts. All page types are referred to as "Pages" in these contexts, but pieces have unique labels, for example, in the manager modal where it might display "All Articles."
+Similar to `label` for all doc types, the `pluraLabel` option sets the string the user interface will use to describe a piece type in plural contexts. All page types are referred to as "Pages" in these contexts, but pieces should have unique labels (e.g., "Articles," or "Teams").
 
 If no `pluralLabel` value is provided, Apostrophe will append the `label` (whether set manually or generated [as described](#label)), with "s", as is typical for English words. **Even in English this is often not correct, so `pluralLabel` should usually be defined explicitly.**
 
@@ -312,7 +312,7 @@ module.exports = {
 
 ### `perPage`
 
-In piece type modules, the `perPage` option, set to an integer, sets the number of pieces that will be returned in each "page" [during `GET` requests](api/pieces.md#get-api-v1-piece-name) that don't specify an `_id`. This value defaults to 10.
+In piece types, the `perPage` option, expressed as an integer, sets the number of pieces that will be returned in each "page" [during `GET` requests](api/pieces.md#get-api-v1-piece-name) that don't specify an `_id`. This value defaults to 10.
 
 #### Example
 
@@ -354,7 +354,7 @@ Unauthenticated [`GET /api/v1/article`](api/pieces.md#get-api-v1-piece-name) req
 
 ### `quickCreate`
 
-Setting `quickCreate` to the boolean `true` on a piece adds that piece type to the admin bar "quick create" menu. The Apostrophe admin bar user interface includes the quick create menu button to add new pieces without first opening their respective manager modals. This is a useful setting for the piece types that editors will be adding most often.
+Setting `quickCreate: true` on a piece adds that piece type to the admin bar "quick create" menu. The Apostrophe admin bar user interface includes the quick create menu button to add new pieces without first opening their respective manager modals.
 
 #### Example
 
@@ -372,7 +372,7 @@ module.exports = {
 ### `searchable`
 
 <!-- TODO: link to documentation of Apostrophe search when available. -->
-By default, all piece types are included in Apostrophe search results. Setting `searchable: false` on a piece type will exclude that piece type from the search results.
+Setting `searchable: false` on a piece type will exclude that piece type from the results in Apostrophe's built-in search.
 
 #### Example
 

--- a/docs/reference/module-options.md
+++ b/docs/reference/module-options.md
@@ -43,6 +43,8 @@ require('apostrophe')({
 
 ## Options for any module
 
+Option settings in this section apply to every module in Apostrophe.
+
 - [`alias`](#alias)
 - [`components`](#components)
 - [`name`](#name)
@@ -136,4 +138,107 @@ You might use that value as a fallback for user-editable fields.
 </h2>
 ```
 
-## Accessing module options
+## Options for all doc type modules
+
+Option settings in this section apply to all modules that extend `@apostrophecms/doc-type` ([doc type](glossary.md#doc) modules). These include all piece and page types.
+
+- [`adminOnly`](#adminonly)
+- [`autopublish`](#autopublish)
+- [`label`](#label)
+- [`localized`](#localized)
+- [`slugPrefix`](#slugprefix)
+<!-- - [`contextBar`](#contextbar) -->
+
+### `adminOnly`
+
+<!-- TODO: link to permissions docs when available. -->
+If `true`, only users with admin-level permissions may edit this doc type. There is no default value.
+
+#### Example
+
+```javascript
+// modules/official-memo/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    adminOnly: true
+  },
+  // ...
+}
+```
+
+### `autopublish`
+
+Set `autopublish` to `true` to automatically publish any changes saved to docs of this type. There is then effectively no draft mode for this doc type. The core image and file modules use this option, for example, and it can be useful for such "utility" piece types that need to have a single, predictable state.
+
+#### Example
+
+```javascript
+// modules/article-category/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    autopublish: true
+  },
+  // ...
+}
+```
+
+<!-- ### `contextBar` -->
+
+<!-- NOTE: Should we keep this on the secrete menu? (not document) -->
+<!-- If `true`, the second row of the admin bar, the "context bar," will be disabled.
+`true` ~ allows the admin bar context bar row to appear -->
+
+### `label`
+
+`label` should be set to a text string to be used in user interface elements related to this doc type. This includes buttons to open piece manager modals and the page type select field.
+
+If not set, Apostrophe will convert the module `name` meta property to a readable label by splitting the `name` on dashes and underscores, then capitalizing the first letter of each word.
+
+#### Example
+
+```javascript
+// modules/feature/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    label: 'Featured Article'
+  },
+  // ...
+}
+```
+
+### `localized`
+
+Defaults to `true`. If set to `false`, this doc type will _not_ be included in the locale system. This means there will be only one version of each doc, regardless of whether multiple locales (e.g., for languages or regions) are active. The "users" piece disables localization in this way.
+
+#### Example
+
+```javascript
+// modules/administrative-category/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    localized: false
+  },
+  // ...
+}
+```
+
+### `slugPrefix`
+
+Set `slugPrefix` to a string to prepend all [slugs](glossary.md#slug) for docs of this type. This can be useful to help prevent slugs, which must be unique for each doc in the database, from being reserved in some cases. For example, Apostrophe image docs have the `slugPrefix` value of `'image-'` so images, which do not typically have public pages, do not accidentally reserve a more reader-friendly slug.
+
+#### Example
+
+```javascript
+// modules/article-category/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    slugPrefix: 'category-'
+  },
+  // ...
+}
+```

--- a/docs/reference/module-options.md
+++ b/docs/reference/module-options.md
@@ -146,6 +146,7 @@ Option settings in this section apply to all modules that extend `@apostrophecms
 - [`autopublish`](#autopublish)
 - [`label`](#label)
 - [`localized`](#localized)
+- [`sort`](#sort)
 - [`slugPrefix`](#slugprefix)
 <!-- - [`contextBar`](#contextbar) -->
 
@@ -226,6 +227,40 @@ module.exports = {
 }
 ```
 
+### `sort`
+
+The `sort` option for a doc type defines a sorting order for requests to the database for that type. This setting generally follows the [MongoDB `$sort` aggregation](https://docs.mongodb.com/manual/reference/operator/aggregation/sort/) syntax. The option is set to an object containing field name keys with `1` as a property value for ascending order and `-1` for descending order.
+
+The default sort for all doc types is `{ updatedAt: -1 }`, meaning it returns documents based on the `updatedAt` property (the date and time of the last update) in descending order. The `sort` object can have multiple keys for more specific sorting.
+
+#### Example
+
+This `sort` setting will return articles first based on a custom `priority` field in ascending order, then by the core `updatedAt` property in descending order.
+
+```javascript
+// modules/article/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    sort: {
+      priority: 1,
+      updatedAt: -1
+    }
+  },
+  fields: {
+    add: {
+      priority: {
+        type: 'integer',
+        min: 1,
+        max: 5
+      },
+      // ...
+    }
+  }
+  // ...
+}
+```
+
 ### `slugPrefix`
 
 Set `slugPrefix` to a string to prepend all [slugs](glossary.md#slug) for docs of this type. This can be useful to help prevent slugs, which must be unique for each doc in the database, from being reserved in some cases. For example, Apostrophe image docs have the `slugPrefix` value of `'image-'` so images, which do not typically have public pages, do not accidentally reserve a more reader-friendly slug.
@@ -242,3 +277,118 @@ module.exports = {
   // ...
 }
 ```
+
+## Options for all piece modules
+
+Option settings in this section apply to all piece modules (those that extend `@apostrophecms/piece-type`).
+
+<!-- - [`createControls`](#createcontrols)
+- [`editControls`](#editcontrols) -->
+- [`pluralLabel`](#plurallabel)
+- [`perPage`](#perpage)
+- [`publicApiProjection`](#publicapiprojection)
+- [`quickCreate`](#quickcreate)
+- [`searchable`](#searchable)
+
+<!-- ### `createControls`
+ (don't doc)
+### `editControls`
+ (don't doc) -->
+
+### `pluralLabel`
+
+Similar to `label` for all doc types, the `pluraLabel` option sets the string the user interface will use to describe a piece type in plural contexts. All page types are referred to as "Pages" in these contexts, but pieces have unique labels, for example, in the manager modal where it might display "All Articles."
+
+If no `pluralLabel` value is provided, Apostrophe will append the `label` (whether set manually or generated [as described](#label)), with "s", as is typical for English words. **Even in English this is often not correct, so `pluralLabel` should usually be defined explicitly.**
+
+#### Example
+
+```javascript
+// modules/goose/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    label: 'Goose',
+    pluralLabel: 'Geese'
+  },
+  // ...
+}
+```
+
+### `perPage`
+
+In piece type modules, the `perPage` option, set to an integer, sets the number of pieces that will be returned in each "page" [during `GET` requests](api/pieces.md#get-api-v1-piece-name) that don't specify an `_id`. This value defaults to 10.
+
+#### Example
+
+```javascript
+// modules/article/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    perPage: 20 // REST `GET` requests will return 20 pieces per page.
+  },
+  // ...
+}
+```
+
+### `publicApiProjection`
+
+By default the built-in Apostrophe REST APIs are not accessible without proper [authentication](/reference/api/authentication.md). You can set an exception to this for `GET` requests to return specific document properties with the `publicApiProjection` option.
+
+This should be set to an object containing individual field name keys set to `1` for their values. Those fields names included in the `publicApiProjection` object will be returned when the `GET` API requests are made without authentication.
+
+#### Example
+
+```javascript
+// modules/article/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    publicApiProjection: {
+      title: 1,
+      authorName: 1,
+      _url: 1 // 👈 Dynamic properties are allowed
+    }
+  },
+  // ...
+}
+```
+
+Unauthenticated [`GET /api/v1/article`](api/pieces.md#get-api-v1-piece-name) requests would return each piece with only the title, `authorName`, and `_url` properties.
+
+### `quickCreate`
+
+Setting `quickCreate` to the boolean `true` on a piece adds that piece type to the admin bar "quick create" menu. The Apostrophe admin bar user interface includes the quick create menu button to add new pieces without first opening their respective manager modals. This is a useful setting for the piece types that editors will be adding most often.
+
+#### Example
+
+```javascript
+// modules/article/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    quickCreate: true
+  },
+  // ...
+}
+```
+
+### `searchable`
+
+<!-- TODO: link to documentation of Apostrophe search when available. -->
+By default, all piece types are included in Apostrophe search results. Setting `searchable: false` on a piece type will exclude that piece type from the search results.
+
+#### Example
+
+```javascript
+// modules/article/index.js
+module.exports = {
+  extend: '@apostrophecms/piece-type',
+  options: {
+    searchable: false
+  },
+  // ...
+}
+```
+

--- a/docs/reference/module-options.md
+++ b/docs/reference/module-options.md
@@ -153,7 +153,7 @@ Option settings in this section apply to all modules that extend `@apostrophecms
 ### `adminOnly`
 
 <!-- TODO: link to permissions docs when available. -->
-If `true`, only users with admin-level permissions may edit this doc type. There is no default value.
+If `true`, only users with the sitewide admin permission can read or write docs of this type. The `@apostrophecms/user` module uses this setting due to its impact on user access. There is no default value.
 
 #### Example
 
@@ -170,7 +170,9 @@ module.exports = {
 
 ### `autopublish`
 
-Set `autopublish` to `true` to automatically publish any changes saved to docs of this type. There is then effectively no draft mode for this doc type. The core image and file modules use this option, for example, and it can be useful for such "utility" piece types that need to have a single, predictable state.
+Set `autopublish` to `true` to automatically publish any changes saved to docs of this type. There is then effectively no draft mode for this doc type.
+
+The core image and file modules use this option, for example. It eliminates the need for users to think about the distinction between draft and published content while preserving the possibility of translation for different locales.
 
 #### Example
 
@@ -282,18 +284,11 @@ module.exports = {
 
 Option settings in this section apply to all piece modules (those that extend `@apostrophecms/piece-type`).
 
-<!-- - [`createControls`](#createcontrols)
-- [`editControls`](#editcontrols) -->
 - [`pluralLabel`](#plurallabel)
 - [`perPage`](#perpage)
 - [`publicApiProjection`](#publicapiprojection)
 - [`quickCreate`](#quickcreate)
 - [`searchable`](#searchable)
-
-<!-- ### `createControls`
- (don't doc)
-### `editControls`
- (don't doc) -->
 
 ### `pluralLabel`
 


### PR DESCRIPTION
Adds additional module option documentation. Specifically covers doc type and piece type options, with examples. Also other related documentation improvements.