### PR TITLE
npm cli install as global "-g" missing added

### DIFF
--- a/docs/guide/setting-up.md
+++ b/docs/guide/setting-up.md
@@ -31,7 +31,7 @@ There is [an official CLI](https://www.npmjs.com/package/@apostrophecms/cli) for
 Install the CLI tool:
 
 ```bash
-npm install @apostrophecms/cli
+npm install -g @apostrophecms/cli
 # Or `yarn install`, if you prefer. We'll stick to npm commands.
 ```
 


### PR DESCRIPTION
Missing -g prefix added for cli install command