### PR TITLE
add readonly notes on apt fields

### DIFF
--- a/docs/reference/field-types/array.md
+++ b/docs/reference/field-types/array.md
@@ -50,6 +50,7 @@ contactInfo: {
 |`min` | Integer |  n/a | The minimum number of entries required in the array |
 |`max` | Integer |  n/a | The maximum number of entries allowed in the array |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value
 |`titleField` | String |  n/a | The name of one of the array schema fields. If provided, the user interface will use the value of that field as a label for the array tabs. |
 
 ::: tip NOTE
@@ -60,7 +61,6 @@ contactInfo: {
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | `false` | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | `false` | If `true`, prevents the user from editing the field value | -->
 
 ## Configuring the array field schema
 

--- a/docs/reference/field-types/attachment.md
+++ b/docs/reference/field-types/attachment.md
@@ -35,13 +35,13 @@ resume: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) | universal |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |`aspectRatio` | Array | n/a | Only applies to image files. If set to an array like `[ 2, 1 ]`, the image must have that aspect ratio and will be autocropped if the user does not manually crop. Only suitable if fileGroup is images. | -->
 <!-- |`contextual` | Boolean | `false` | If `true`, it will prevent the field from appearing in the editor modal | -->
 <!-- |`crop` | Boolean | `false` | Only applies to image files. If `true`, the user may crop the attachment. Only suitable if fileGroup is images. | -->
 <!-- |`minSize` | Array | n/a | Only applies to image files. if set to an array like `[ 640, 480 ]`, the image must have at least the specified minimum width and height. Only suitable if fileGroup is images. | -->
-<!-- |`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value | -->
 
 ::: warning NOTE
 The uploaded files are stored in a web-accessible folder, however their file names are prepended with a randomized ID to avoid naming collisions.

--- a/docs/reference/field-types/boolean.md
+++ b/docs/reference/field-types/boolean.md
@@ -30,12 +30,12 @@ isSpecial: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) | universal |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 |`toggle` | Boolean/Object | n/a | If set to `true` or a configuration object, the field will use an alternate "toggle" interface. See below. |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
 <!-- |mandatory | String |  | If set, the string is displayed if the user does not set the field to the `true` choice. This can be used for required confirmation fields. | | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Customizing boolean field labels
 

--- a/docs/reference/field-types/checkboxes.md
+++ b/docs/reference/field-types/checkboxes.md
@@ -45,10 +45,10 @@ genres: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## `choices` configuration
 

--- a/docs/reference/field-types/color.md
+++ b/docs/reference/field-types/color.md
@@ -32,11 +32,11 @@ themeColor: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 |`options` | Object | n/a | An object containing color picker configuration. See below. |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ### `options`
 

--- a/docs/reference/field-types/date.md
+++ b/docs/reference/field-types/date.md
@@ -32,10 +32,10 @@ birthday: {
 |`max` | String | n/a | The maximum allowed date value for the field. Must be a date format (e.g., `YYYY-MM-DD`) |
 |`min` | String | n/a | The minimum allowed date value for the field. Must be a date format (e.g., `YYYY-MM-DD`) |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Use in templates
 

--- a/docs/reference/field-types/email.md
+++ b/docs/reference/field-types/email.md
@@ -28,10 +28,10 @@ workEmail: {
 |`help` | String | n/a | Help text for the content editor |
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`required` | Boolean | false | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Use in templates
 

--- a/docs/reference/field-types/float.md
+++ b/docs/reference/field-types/float.md
@@ -33,10 +33,10 @@ gpa: {
 |`max` | Number | n/a | The maximum allowed value for the field |
 |`min` | Number | n/a | The minimum allowed value for the field |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Use in templates
 

--- a/docs/reference/field-types/integer.md
+++ b/docs/reference/field-types/integer.md
@@ -34,10 +34,10 @@ rating: {
 |`max` | Number | n/a | The maximum allowed value for the field |
 |`min` | Number | n/a | The minimum allowed value for the field |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Use in templates
 

--- a/docs/reference/field-types/oembed.md
+++ b/docs/reference/field-types/oembed.md
@@ -36,10 +36,10 @@ video: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Use in templates
 

--- a/docs/reference/field-types/password.md
+++ b/docs/reference/field-types/password.md
@@ -32,10 +32,10 @@ secret: {
 |`min` | Integer | n/a | Sets the minimum number of characters allowed |
 |`max` | Integer | n/a | Sets the maximum number of characters allowed |
 |`required` | Boolean | false | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Use in templates
 

--- a/docs/reference/field-types/radio.md
+++ b/docs/reference/field-types/radio.md
@@ -53,10 +53,10 @@ animalType: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 <!-- |widgetControls | Boolean | false | If `true`, `select` fields can be edited in line on the page if the field is in a widget | | -->
 
 ## `choices` configuration

--- a/docs/reference/field-types/range.md
+++ b/docs/reference/field-types/range.md
@@ -34,12 +34,12 @@ fontSize: {
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`max` | Number | n/a | The maximum allowed value for the field |
 |`min` | Number | n/a | The minimum allowed value for the field |
-|`required` | Boolean | `false` | If `true`, the field is mandatory |
 |`step` | Number | 1 | The interval between numbers (it may be a floating point number) |
+|`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Use in templates
 

--- a/docs/reference/field-types/relationship-reverse.md
+++ b/docs/reference/field-types/relationship-reverse.md
@@ -32,6 +32,7 @@ _pizzas: {
 |`reverseOf` | String | n/a | Set to the name of the related `relationship` field. |
 |`ifOnlyOne` | Boolean | `false` | If `true`, it will only reveal the relationship data if the doc query returned only one document. [See below](#ifonlyone) for more. |
 |`withType` | String | Uses the field name, minus its leading `_` and possible trailing `s` | The name of the related type. |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 ::: tip
 For relationships with pages, use `withType: '@apostrophecms/any-page-type'`.

--- a/docs/reference/field-types/relationship.md
+++ b/docs/reference/field-types/relationship.md
@@ -54,6 +54,7 @@ _toppings: {
 |`min` | Integer |  n/a | The minimum number of related docs required |
 |`max` | Integer |  n/a | The maximum number of related docs allowed |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 |`withRelationships` | Array |  n/a | An array of field names representing `relationship` fields you wish to populate with the connected docs. [See below](#populating-nested-relationships-using-withrelationship) for more. |
 |`withType` | String | Uses the field name, minus its leading `_` and possible trailing `s` | The name of the related type. |
 
@@ -62,9 +63,6 @@ To create relationships with pages, use `withType: '@apostrophecms/any-page-type
 
 If `withType` is not set the name of the field must match the name of the related type, with a leading `_` (underscore), and *optional* trailing `s` added (e.g., `_article` or `_articles` to connect to the `article` piece type).
 :::
-
-<!-- TODO: The following settings are likely to return, but are not yet implemented. -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Filtering related document properties
 

--- a/docs/reference/field-types/select.md
+++ b/docs/reference/field-types/select.md
@@ -45,10 +45,10 @@ theme: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 <!-- |widgetControls | Boolean | false | If `true`, `select` fields can be edited in line on the page if the field is in a widget | | -->
 
 ## `choices` configuration

--- a/docs/reference/field-types/slug.md
+++ b/docs/reference/field-types/slug.md
@@ -34,12 +34,12 @@ projectSlug: {
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`page` | Boolean | `false` | If `true`, then slashes are allowed since the slug field is describing a page doc |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: 2.x options not yet available -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
 <!-- |pattern | String | | Regular expression to validate entries |
 |patternErrorMessage | String | | Error message to display if `pattern` does not match | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ::: tip
 If you are overriding a piece type or page type's `slug` field and that doc type uses a [slug prefix](/reference/module-api/module-options.md#slugprefix), the `slug` field should include `'archived'` in the `following` option. It is used by the slug field type to manage prefixes, though its value is not included in the slug name.

--- a/docs/reference/field-types/string.md
+++ b/docs/reference/field-types/string.md
@@ -41,6 +41,7 @@ biography: {
 |`min` | Integer | n/a | Sets the minimum number of characters allowed |
 |`max` | Integer | n/a | Sets the maximum number of characters allowed |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 |`sortify` |	Boolean |	`false` |	If true, creates "sortified" fields. See below. |
 |`textarea` | Boolean | `false` | If `true`, use a textarea interface with multiple lines, which allows line breaks |
 
@@ -49,7 +50,6 @@ biography: {
 <!-- |pattern | String | | Regular expression to validate entries |
 |patternErrorMessage | String | | Error message to display if `pattern` does not match | -->
 <!-- |searchable | Boolean | true | If false, content from the area will not appear in search results. | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## `sortify`
 

--- a/docs/reference/field-types/time.md
+++ b/docs/reference/field-types/time.md
@@ -30,10 +30,10 @@ eventTime: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ::: warning NOTE
 If you do not set `def: null` or `required: true`, the time defaults to the current time.

--- a/docs/reference/field-types/url.md
+++ b/docs/reference/field-types/url.md
@@ -32,10 +32,10 @@ portfolio: {
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) |
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
+|`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->
-<!-- |readOnly | Boolean | false | If `true`, prevents the user from editing the field value | -->
 
 ## Use in templates
 


### PR DESCRIPTION
## Summary

Adds `readOnly` param in appropriate field schemas

## What are the specific steps to test this change?

*For example:*
> 1. See the most fields (string, date, select, etc) have a `readOnly` property and desc

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
