### PR TITLE
Corrects minor errors in documentation

### DIFF
--- a/docs/cookbook/ubuntu-hosting.md
+++ b/docs/cookbook/ubuntu-hosting.md
@@ -6,7 +6,7 @@ We'll start off by creating an Ubuntu VPS on AWS Lightsail. There are many servi
 
 1. In an [AWS Lightsail account](https://lightsail.aws.amazon.com), log in and  create an **Ubuntu 20.04 LTS** ("OS Only") instance. You need at least 1GB of RAM. We suggest 2GB to be safe.
    - There is a step on this first page to select or add an SSH key to connect securely from your computer. Follow Lightsail's directions to do this.
-2. Completely any additional configurations you want, then **create the instance**. Once the instance is created, click on it to continue configuration.
+2. Complete any additional configurations you want, then **create the instance**. Once the instance is created, click on it to continue configuration.
 3. On the "Networking" tab, you should see that the SSH and HTTP ports are already open. In addition, **open the HTTPS port** by clicking "Add rule" and selecting "HTTPS." You need this for `https://` connections.
    - Wait a couple minutes even after it says it's ready, to be sure it will accept your SSH connection.
 4. SSH to your server's `ubuntu` account, according to the Lightsail instructions. This account has `sudo` privileges so you can take care of tasks that require root access.

--- a/docs/guide/core-widgets.md
+++ b/docs/guide/core-widgets.md
@@ -172,7 +172,7 @@ This widget won't allow the editor to select any image under 1000 pixels wide, o
 
 ### Specifying an aspect ratio
 
-You can specify a minimum size for any image widget:
+You can specify an aspect ratio for any image widget:
 
 ```js
 // modules/@apostrophecms/home-page/index.js

--- a/docs/reference/api/authentication.md
+++ b/docs/reference/api/authentication.md
@@ -113,7 +113,7 @@ Using the session cookie, send a `POST` request to `/api/v1/@apostrophecms/login
 
 ```javascript
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/@apostrophecms/login/login', {
+const response = await fetch('http://example.net/api/v1/@apostrophecms/login/logout', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
Makes 3 changes to the documentation in the areas indicated in the commit message.

1. In the Authorization->Session cookies->End session section the code snippet for destroying the session cookie on logout is:
```
const response = await fetch('http://example.net/api/v1/@apostrophecms/login/login', {
...
});
```
Instead it should be:
```
const response = await fetch('http://example.net/api/v1/@apostrophecms/login/logout', {
...
});
```
This commit corrects the code snippet appropriately.

2. The first sentence in the image widget aspect ratio documentation was identical to the minimum size first sentence.
3. The Ubuntu hosting cookbook contained a minor grammatical error in the second step.