### PR TITLE
Webpack extension options

### DIFF
--- a/docs/guide/webpack.md
+++ b/docs/guide/webpack.md
@@ -122,8 +122,9 @@ By contrast, if you use different extension names, two separate modules can cont
 
 ### Passing extensions options from any modules
 
-Webpack extensions can also be function that take an `options` parameter.
-From any module, you can declare a `extensionOptions` property in your webpack object. For each webpack extension found in the project, it will look for all `extensionOptions` of the same name and reduce them in a single options object passed to the extension itself.
+Webpack extensions can also be functions that take an `options` parameter.
+From any module, you can declare an `extensionOptions` property in your webpack object. 
+For each webpack extension found in the project, it will look for all `extensionOptions` of the same name and reduce them in a single options object passed to the extension itself.
 
 Example:
 
@@ -213,7 +214,8 @@ Following this example, the options object passed to the `addAlias` extension wi
 }
 ```
 
-This way you'll be able to contribute to any webpack extension from any module.
+This way you'll be able to contribute to any webpack extension from any module in a flexible.
+This feature should only be useful in certain specific cases.
 
 ## Extra bundles
 


### PR DESCRIPTION
[PRO-2840](https://linear.app/apostrophecms/issue/PRO-2840/[michelin-p1]-ability-to-pass-options-to-a-webpack-extension)

## Summary

Documentation for the feature described in the ticket above.

## What are the specific steps to test this change?

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

