### PR TITLE
Add section on filters to guide->templating

### DIFF
--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -40,6 +40,7 @@ module.exports = {
             'guide/templating.md',
             'guide/layout-template.md',
             'guide/template-data.md',
+            'guide/template-filters.md',
             'guide/fragments.md'
           ]
         },

--- a/docs/guide/layout-template.md
+++ b/docs/guide/layout-template.md
@@ -1,4 +1,4 @@
-# Layout Templates
+# Layout templates
 
 A layout template is common in most Apostrophe apps. As the name suggests, it **contains the markup that surrounds page content and is mostly consistent across the website**. Website navigation and footers are both usually in the layout template, whether directly as markup or included from template partials.
 

--- a/docs/guide/template-filters.md
+++ b/docs/guide/template-filters.md
@@ -1,22 +1,25 @@
-# Template Filters
+# Template filters
 
 ## Nunjucks supplied filters
 The Nunjucks templating language comes with several [built-in filters](https://mozilla.github.io/nunjucks/templating.html#filters). These filters apply functions to template data before outputting content to the page. They are called with a pipe operator `|` and can take arguments.
+
 ```markup
 <h1>{{ data.page.headline | replace("foo", "bar" ) | upper }}</h1>
 ```
-In this example, a hypothetical page headline will be retrieved from the page data and then piped to the 'replace' filter, along with two arguments. This filter will scan the incoming data and replace any instances of 'foo' with 'bar'. The output of this filter will then pass the result to the upper function, which will return the input as an uppercase string before being output to the page.
 
->Note: The order of filters can be important, as they are applied sequentially to the input data.
+In this example, a hypothetical page headline will be retrieved from the page data and then piped to the 'replace' filter, along with two arguments. This filter will scan the incoming data and replace any instances of ‘foo’ with 'bar'. The output of this filter will then pass the result to the upper function, which will return the input as an uppercase string before being output to the page.
+
+>Note: The order of filters can be significant, as they are applied sequentially to the input data.
 
 ## Apostrophe supplied filters
-There are several custom filters and filter sets (multiple, sequential filters) used in Apostrophe templating. Rather than have to remember each filter and the correct order, apostrophe exposes them automatically to the templates. In addition, Apostrophe also adds multiple "helper functions" which do not use the `| foo` filter syntax. These are documented with the modules that provide them. Several of the more common of these are within the documentation for the [util module](/reference/modules/util.html#template-helpers).
+
+Several custom filters and filter sets (multiple, sequential filters) are used in Apostrophe templating. Rather than remembering each filter and the correct order, apostrophe exposes them automatically to the templates. In addition, Apostrophe also adds multiple "helper functions" which do not use the `| foo` filter syntax. The most common of these are described in the [alphabetical filter reference](/guide/template-filters.html#alphabetical-apostrophe-filter-reference).
 
 ## Custom template filters
-If you have special template needs you can also construct custom filters for use in Nunjucks templates. They can be added by passing the filter name and function to the template module `addFilter(name, function)` method. Multiple filters can be added by passing an object to this same method where each key is the name of the filter and the value is the function.
+
+If you have special template needs you can also construct custom filters for use in Nunjucks templates. They can be added by passing the filter name and function to the template module `addFilter(name, function)` method. Multiple filters can be added by passing an object to this same method, where each key is the name of the filter and the value is the function.
 
 By way of example, we'll create a link where the URL is included as part of the label, but without the protocol.
-
 ```javascript
 // lib/modules/link-widgets/index.js
 module.exports = {
@@ -58,12 +61,12 @@ module.exports = {
   }
 };
 ```
-Within the `methods` we create a function `stripHttp()` that takes a string from the template. It then returns that same string after performing a RegExp replace to strip the protocol.
 
-In `init()`, we pass our function to the template module using `self.apos.template.addFilter({})`. This method takes the name of the filter that will be used in the template as a property - in this case `stripHttp` - and our new function as a value.
+Within the `methods`, we create a function `stripHttp()` that takes a string from the template. It performs a RegExp replace to strip the protocol before returning the string.
+
+In `init()`, we pass our function to the template module using `self.apos.template.addFilter({})`. This method takes the name of the filter that will be used in the template as property - in this case `stripHttp` - and our new function as a value.
 
 To use this new filter you would simply pipe your data to the filter from within the template.
-
 ```markup
 // lib/modules/link-widgets/views/widget.html
 <section data-link-widget>
@@ -72,19 +75,15 @@ To use this new filter you would simply pipe your data to the filter from within
 ```
 
 ## Alphabetical Apostrophe filter reference
-
 ### `| build(url, path, data)`
 
-Given a URL, this filter can add both path and query string parameters. This is very useful for adding filters to the current URL, respecting other filters already present, without complicated logic.
-
+This filter can add path and query string parameters to the passed URL. This is very useful for adding filters to the current URL, respecting other filters already present, without complicated logic.
 The method in the `url` module requires that the URL be passed in as the first argument. However, when using this as a filter in Nunjucks, the data before the pipe will be sent as the first argument. This parameter accepts a URL that can include query parameters and anchor tags.
 
-The `path` parameter accepts an array but is optional. If present, it allows the addition of additional path elements to the URL. The array strings are not added directly to the URL but are substituted with values from the data object. So, with a `path` array of `['one', 'two']` and a `data` object of `{ one: 'first', two: 'second'}` the URL `https://example.com` would be modified to `https://example.com/first/second`. The path elements will be added in the order they appear in the `path` array.
-
+The `path` parameter accepts an array but is optional. If present, it allows the addition of additional path elements to the URL. The array strings are not added directly to the URL but are substituted with values from the `data` object. So, with a `path` array of `['one', 'two']` and a `data` object of `{ one: 'first', two: 'second'}` the URL `https://example.com` would be modified to `https://example.com/first/second`. The path elements will be added in the order they appear in the `path` array.
 The `data` parameter accepts an object. As outlined for `path`, these can be key:value pairs that add new path elements. If the key does not match any element in the `path` array, it will be added to the URL as a query parameter. Continuing with the example URL from above, passing a `data` object of `{ id: 1010 }` would result in a filtered URL of `https://example.com?id=1010`. If the query parameter already exists in the URL, the value will be changed to the value in the `data` object. Passing values of `null`, `undefined`, or an empty string will remove the query parameter.
 
-If the `data` object contains a key that matches a string in the `path` array and has an invalid path value, e.g. `null`, or is not slug safe, all path processing will stop, and any additional `data` key:value pairs will be added as query parameters even if they match with a `path` array value.
-
+If the `data` object contains a key that matches a string in the `path` array and has an invalid path value, e.g. `null`, or is not slug safe, all path processing will stop. Any additional `data` key:value pairs will be added as query parameters even if they match a `path` array value.
 Since passing a parameter of the same name as an existing query parameter will replace the value, building an array property for a query requires MongoDB-style operators. If an array doesn’t already exist, the `$addToSet` operator will create it and add a value. Otherwise, it will simply add the value.
 
 `{ colors: { $addToSet: ‘blue’ } }`
@@ -97,48 +96,36 @@ For additional detail, you can examine the code comments in the `url` module [`i
 
 ### `| clonePermanent`
 
-Given JavaScript data, this filter recursively strips out any properties whose names beginning with a `_`, except `_id`. This is used to avoid pushing large documents into the DOM, keeping markup size down. This filter is usually followed by either `json` or `jsonAttribute`.
-
+Given JavaScript data, this filter recursively strips out any properties whose names begin with a `_`, except `_id`. This is used to avoid pushing large documents into the DOM, keeping markup size down. This filter is usually followed by either the `json` or `jsonAttribute` filters.
 ### `| css`
-
 Converts a string from other formats, such as underscore or camelCase to a kebab-case CSS identifier. For instance, `fooBar` becomes `foo-bar`.
-
 ### `| date(format)`
 
-Turns a JavaScript Date object into a string, as specified by `format`. For formatting options, see [the documentation of the `dayjs` npm module](https://day.js.org/docs/en/display/format).
-
+Turns a JavaScript Date object into a string, as specified by `format`. For formatting options, see the documentation of the `dayjs` npm module.
 ### `| json`
 
-Turns JavaScript data into a JSON string, **correctly escaped for safe use inside a** `script` **tag in the middle of an HTML document.** Note that it is **not** safe to use the Nunjucks `dump` filter in this way. This filter is not for attributes, see `jsonAttribute`.
-
+Turns JavaScript data into a JSON string, **correctly escaped for safe use inside a** `script` **tag in the middle of an HTML document.** Note that it is **not** safe to use the Nunjucks `dump` filter in this way. This filter is not for attributes; see `jsonAttribute`.
 ### `| jsonAttribute(options)`
-
 Given JavaScript data, this filter escapes it correctly to be the value of a `data-` attribute of an element in the page. It does not add the `"` quote characters around the attribute itself, but it does escape any `"` characters in the JSON string.
 
-`options` may be omitted. If `options.single` is truthy, single-quotes are escaped instead, and you must use `'` \(single quotes\) to quote the attribute. This saves space and is more readable in "view page source."
+`options` may be omitted. If `options.single` is truthy, single-quotes are escaped instead, and you must use `'` (single quotes) to quote the attribute. This saves space and is more readable in "view page source."
 
-**If this filter is applied to anything other than an object or array,** the value is converted to a string and output literally, without quotes. This is done for compatibility with jQuery's `data` method, which only parses JSON when it sees `{}` or `[]` syntax, and otherwise returns the value directly as a string. If you don't like this, only pass objects to this filter.
+**If this filter is applied to anything other than an object or array**, the value is converted to a string and output literally, without quotes. This is done for compatibility with jQuery's `data` method, which only parses JSON when it sees `{}` or `[]` syntax, and otherwise returns the value directly as a string. If you don't like this, only pass objects to this filter.
 
 ### `| merge(object2, object3...)`
-
 When applied to an object, this filter "merges in" the properties of any additional objects given to it as arguments. Note that this is not a recursive merge. If two objects contain the same property, the last object wins.
-
 ### `| nlbr`
 
-Converts newlines found in a string into `<br />` tags. The incoming string is escaped from any HTML markup. Following conversion of the newlines into breaks, the string is passed through the `|safe` filter before returning it.
-
+Converts newlines found in a string into `<br />` tags. The incoming string is escaped from any HTML markup. After converting the newlines into breaks, the string is passed through the `|safe` filter before returning it.
 ### `| nlp`
-
 Breaks a string into `<p>...</p>` elements, based on newlines. Like the `| nlbr` filter, the incoming string is escaped and passed back as safe.
-
 ### `| query`
 
-Turns an object into a query string. See also `build`.
+Turns an object into a query string. This filter uses the stringify method of the npm (‘qs’ package)[https://www.npmjs.com/package/qs]. See also `build`.
 
-## `| safe`
+### `| safe`
 
-The `| safe` filter marks any passed value as safe for direct output on the page. This filter is built into Nunjucks, but merits special mention. Data passed into templates is automatically escaped, thus there is no need for the `| escape` (aliased as `| e`) filter. However, is you want to bypass this behavior you need to pass any data through the `| safe` filter. This should be used with some caution as this could allow the Editor to pass HTML breaking code onto the page.
+The `| safe` filter marks any passed value as safe for direct output on the page. This filter is built into Nunjucks but merits special mention. Data passed from Apostrophe into templates is automatically escaped. Thus, there is no need for the `| escape` (aliased as `| e`) filter. However, if you want to bypass this behavior, you must pass any data through the `| safe` filter. This should be used with caution as this could allow the Editor to pass HTML breaking code onto the page.
 
 ### `| striptags`
-
 Strips HTML tags from a string, leaving only the content inside the tags.

--- a/docs/guide/template-filters.md
+++ b/docs/guide/template-filters.md
@@ -9,11 +9,11 @@ In this example, a hypothetical page headline will be retrieved from the page da
 
 >Note: The order of filters can be important, as they are applied sequentially to the input data.
 
-## Apostrophe supplied Filters
+## Apostrophe supplied filters
 There are several custom filters and filter sets (multiple, sequential filters) used in Apostrophe templating. Rather than have to remember each filter and the correct order, apostrophe exposes them automatically to the templates. In addition, Apostrophe also adds multiple "helper functions" which do not use the `| foo` filter syntax. These are documented with the modules that provide them. Several of the more common of these are within the documentation for the [util module](/reference/modules/util.html#template-helpers).
 
 ## Custom template filters
-If you have special template needs you can also construct custom filters for use in Nunjucks templates.
+If you have special template needs you can also construct custom filters for use in Nunjucks templates. By way of example, we'll create a link where the URL is included as part of the label
 
 ```javascript
 // lib/modules/link-widgets/index.js

--- a/docs/guide/template-filters.md
+++ b/docs/guide/template-filters.md
@@ -1,0 +1,118 @@
+# Template Filters
+
+## Nunjucks supplied filters
+The Nunjucks templating language comes with several [built-in filters](https://mozilla.github.io/nunjucks/templating.html#filters). These filters apply functions to template data before outputting content to the page. They are called with a pipe operator `|` and can take arguments.
+```markup
+<h1>{{ data.page.headline | replace("foo", "bar" ) | upper }}</h1>
+```
+In this example, a hypothetical page headline will be retrieved from the page data and then piped to the 'replace' filter, along with two arguments. This filter will scan the incoming data and replace any instances of 'foo' with 'bar'. The output of this filter will then pass the result to the upper function, which will return the input as an uppercase string before being output to the page.
+
+>Note: The order of filters can be important, as they are applied sequentially to the input data.
+
+## Apostrophe supplied Filters
+There are several custom filters and filter sets (multiple, sequential filters) used in Apostrophe templating. Rather than have to remember each filter and the correct order, apostrophe exposes them automatically to the templates. In addition, Apostrophe also adds multiple "helper functions" which do not use the `| foo` filter syntax. These are documented with the modules that provide them. Several of the more common of these are within the documentation for the [util module](/reference/modules/util.html#template-helpers).
+
+## Custom template filters
+If you have special template needs you can also construct custom filters for use in Nunjucks templates.
+
+```javascript
+// lib/modules/link-widgets/index.js
+module.exports = {
+  extend: '@apostrophecms/widget-type',
+  options: {
+    label: 'Link to a Page'
+  },
+  fields: {
+    add: {
+      url: {
+        type: 'url',
+        label: 'URL',
+        required: true
+      },
+      label: {
+        type: 'string',
+        label: 'Label',
+        required: true
+      }
+    },
+    group: {
+      links: {
+        label: 'Links',
+        fields: [ 'url', 'label' ]
+      }
+    }
+  },
+  init(self) {
+    self.apos.template.addFilter({
+      stripHttp: self.stripHttp
+    });
+  },
+  methods(self) {
+    return {
+      stripHttp(s) {
+        return s.replace(/^(https?:|)\/\//, '');
+      }
+    };
+  }
+};
+```
+To use this filter you would simply pipe your data to the filter.
+
+```markup
+// lib/modules/link-widgets/views/widget.html
+<section data-link-widget>
+  <h2>{{ data.widget.label }}: {{ data.widget.url | stripHttp }}</h2>
+</section>
+```
+
+## Alphabetical Apostrophe filter reference
+
+### `| build(obj...)`
+
+Given a URL and one or more objects, this filter adds query string parameters for each of the properties in the objects. If objects affect the same parameter, the last object wins. If a parameter is set to `null` or the empty string it is removed from the URL altogether. This is very useful for adding filters to the current URL, respecting other filters already present, without complicated logic.
+
+The `build` filter has additional features which you can read about in the comments of the `index.js` file of the url module.
+
+### `| clonePermanent`
+
+Given JavaScript data, this filter recursively strips out any properties whose names beginning with a `_`, except `_id`. This is used to avoid pushing large joined documents into the DOM.
+
+### `| css`
+
+Converts a string to a hyphenated CSS identifier. For instance, `fooBar` becomes `foo-bar`.
+
+### `| date(format)`
+
+Turns a JavaScript Date object into a string, as specified by `format`. For formatting options, see [the documentation of the `momentjs` npm module](https://momentjs.com/docs/#/displaying/format/).
+
+### `| json`
+
+Turns JavaScript data into a JSON string, **correctly escaped for safe use inside a** `script` **tag in the middle of an HTML document.** Note that it is **not** safe to use the Nunjucks `dump` filter in this way. This filter is not for attributes, see `jsonAttribute`.
+
+### `| jsonAttribute(options)`
+
+Given JavaScript data, this filter escapes it correctly to be the value of a `data-` attribute of an element in the page. It does not add the `"` quote characters, but it does escape any `"` characters in the JSON string.
+
+`options` may be omitted. If `options.single` is truthy, single-quotes are escaped instead, and you must use `'` \(single quotes\) to quote the attribute. This saves space and is more readable in "view page source."
+
+**If this filter is applied to anything other than an object or array,** the value is converted to a string and output literally, without quotes. This is done for compatibility with jQuery's `data` method, which only parses JSON when it sees `{}` or `[]` syntax, and otherwise returns the value directly as a string. If you don't like this, only pass objects to this filter.
+
+### `| merge(object2, object3...)`
+
+When applied to an object, this filter "merges in" the properties of any additional objects given to it as arguments, using the lodash `assign` method. Note that this is not a recursive merge. If two objects contain the same property, the last object wins.
+
+### `| nlbr`
+
+Converts newlines found in a string into `<br />` tags.
+
+### `| nlp`
+
+Breaks a string into `<p>...</p>` elements, based on newlines.
+
+### `| query`
+
+Turns an object into a query string. See also `build`.
+
+### `| striptags`
+
+Strips HTML tags from a string, leaving only the content inside the tags.

--- a/docs/guide/template-filters.md
+++ b/docs/guide/template-filters.md
@@ -3,13 +3,20 @@
 ## Nunjucks supplied filters
 The Nunjucks templating language comes with several [built-in filters](https://mozilla.github.io/nunjucks/templating.html#filters). These filters apply functions to template data before outputting content to the page. They are called with a pipe operator `|` and can take arguments.
 
-```markup
+<AposCodeBlock>
+```django
 <h1>{{ data.page.headline | replace("foo", "bar" ) | upper }}</h1>
 ```
+</AposCodeBlock>
+
 
 In this example, a hypothetical page headline will be retrieved from the page data and then piped to the 'replace' filter, along with two arguments. This filter will scan the incoming data and replace any instances of ‘foo’ with 'bar'. The output of this filter will then pass the result to the upper function, which will return the input as an uppercase string before being output to the page.
 
->Note: The order of filters can be significant, as they are applied sequentially to the input data.
+::: note
+
+The order of filters can be significant, as they are applied sequentially to the input data.
+
+:::
 
 ## Apostrophe supplied filters
 
@@ -20,6 +27,8 @@ Several custom filters and filter sets (multiple, sequential filters) are used i
 If you have special template needs you can also construct custom filters for use in Nunjucks templates. They can be added by passing the filter name and function to the template module `addFilter(name, function)` method. Multiple filters can be added by passing an object to this same method, where each key is the name of the filter and the value is the function.
 
 By way of example, we'll create a link where the URL is included as part of the label, but without the protocol.
+
+<AposCodeBlock>
 ```javascript
 // lib/modules/link-widgets/index.js
 module.exports = {
@@ -61,18 +70,22 @@ module.exports = {
   }
 };
 ```
+</AposCodeBlock>
 
 Within the `methods`, we create a function `stripHttp()` that takes a string from the template. It performs a RegExp replace to strip the protocol before returning the string.
 
 In `init()`, we pass our function to the template module using `self.apos.template.addFilter({})`. This method takes the name of the filter that will be used in the template as property - in this case `stripHttp` - and our new function as a value.
 
 To use this new filter you would simply pipe your data to the filter from within the template.
-```markup
-// lib/modules/link-widgets/views/widget.html
+
+<AposCodeBlock>
+```django
+{# lib/modules/link-widgets/views/widget.html #}
 <section data-link-widget>
   <a href="{{ data.widget.url }}">{{ data.widget.label }}: {{ data.widget.url | stripHttp }}</a>
 </section>
 ```
+</AposCodeBlock>
 
 ## Alphabetical Apostrophe filter reference
 ### `| build(url, path, data...)`
@@ -98,6 +111,7 @@ To remove values from an existing array use the `$pull` operator:
 
 Given JavaScript data, this filter recursively strips out any properties whose names begin with a `_`, except `_id`. This is used to avoid pushing large related documents into the DOM, keeping markup size down. This filter is usually followed by either the `json` or `jsonAttribute` filters.
 ### `| css`
+
 Converts a string from other formats, such as underscore or camelCase to a kebab-case CSS identifier. For instance, `fooBar` becomes `foo-bar`.
 ### `| date(format)`
 
@@ -106,6 +120,7 @@ Turns a JavaScript Date object into a string, as specified by `format`. For form
 
 Turns JavaScript data into a JSON string, **correctly escaped for safe use inside a** `script` **tag in the middle of an HTML document.** Note that it is **not** safe to use the Nunjucks `dump` filter in this way. This filter is not for attributes; see `jsonAttribute`.
 ### `| jsonAttribute(options)`
+
 Given JavaScript data, this filter escapes it correctly to be the value of a `data-` attribute of an element in the page. It does not add the `"` quote characters around the attribute itself, but it does escape any `"` characters in the JSON string.
 
 `options` may be omitted. If `options.single` is truthy, single-quotes are escaped instead, and you must use `'` (single quotes) to quote the attribute. This saves space and is more readable in "view page source."
@@ -113,11 +128,13 @@ Given JavaScript data, this filter escapes it correctly to be the value of a `da
 **If this filter is applied to anything other than an object or array**, the value is converted to a string and output literally, without quotes. This is done for compatibility with jQuery's `data` method, which only parses JSON when it sees `{}` or `[]` syntax, and otherwise returns the value directly as a string. If you don't like this, only pass objects to this filter.
 
 ### `| merge(object2, object3...)`
+
 When applied to an object, this filter "merges in" the properties of any additional objects given to it as arguments. Note that this is not a recursive merge. If two objects contain the same property, the last object wins.
 ### `| nlbr`
 
 Converts newlines found in a string into `<br />` tags. The incoming string is escaped from any HTML markup. After converting the newlines into breaks, the string is passed through the `|safe` filter before returning it.
 ### `| nlp`
+
 Breaks a string into `<p>...</p>` elements, based on newlines. Like the `| nlbr` filter, the incoming string is escaped and passed back as safe.
 ### `| query`
 
@@ -128,4 +145,5 @@ Turns an object into a query string. This filter uses the stringify method of th
 The `| safe` filter marks any passed value as safe for direct output on the page. This filter is built into Nunjucks but merits special mention. Data passed from Apostrophe into templates is automatically escaped. Thus, there is no need for the `| escape` (aliased as `| e`) filter. However, if you want to bypass this behavior, you must pass any data through the `| safe` filter. This should be used with caution as this could allow the Editor to pass HTML breaking code onto the page.
 
 ### `| striptags`
+
 Strips HTML tags from a string, leaving only the content inside the tags.

--- a/docs/guide/template-filters.md
+++ b/docs/guide/template-filters.md
@@ -75,7 +75,7 @@ To use this new filter you would simply pipe your data to the filter from within
 ```
 
 ## Alphabetical Apostrophe filter reference
-### `| build(url, path, data)`
+### `| build(url, path, data...)`
 
 This filter can add path and query string parameters to the passed URL. This is very useful for adding filters to the current URL, respecting other filters already present, without complicated logic.
 The method in the `url` module requires that the URL be passed in as the first argument. However, when using this as a filter in Nunjucks, the data before the pipe will be sent as the first argument. This parameter accepts a URL that can include query parameters and anchor tags.

--- a/docs/guide/template-filters.md
+++ b/docs/guide/template-filters.md
@@ -81,9 +81,11 @@ This filter can add path and query string parameters to the passed URL. This is 
 The method in the `url` module requires that the URL be passed in as the first argument. However, when using this as a filter in Nunjucks, the data before the pipe will be sent as the first argument. This parameter accepts a URL that can include query parameters and anchor tags.
 
 The `path` parameter accepts an array but is optional. If present, it allows the addition of additional path elements to the URL. The array strings are not added directly to the URL but are substituted with values from the `data` object. So, with a `path` array of `['one', 'two']` and a `data` object of `{ one: 'first', two: 'second'}` the URL `https://example.com` would be modified to `https://example.com/first/second`. The path elements will be added in the order they appear in the `path` array.
-The `data` parameter accepts an object. As outlined for `path`, these can be key:value pairs that add new path elements. If the key does not match any element in the `path` array, it will be added to the URL as a query parameter. Continuing with the example URL from above, passing a `data` object of `{ id: 1010 }` would result in a filtered URL of `https://example.com?id=1010`. If the query parameter already exists in the URL, the value will be changed to the value in the `data` object. Passing values of `null`, `undefined`, or an empty string will remove the query parameter.
+
+The `data` parameter can accept multiple, comma-separated objects. The objects will be considered sequentially, so if duplicate keys are passed, the value will be assigned from the last passed object. As outlined for `path`, these objects can be key:value pairs that add new path elements. If the key does not match any element in the `path` array, it will be added to the URL as a query parameter. Continuing with the example URL from above, passing a `data` object of `{ id: 1010 }` would result in a filtered URL of `https://example.com?id=1010`. If the query parameter already exists in the URL, the value will be changed to the value in the `data` object. Passing values of `null`, `undefined`, or an empty string will remove the query parameter.
 
 If the `data` object contains a key that matches a string in the `path` array and has an invalid path value, e.g. `null`, or is not slug safe, all path processing will stop. Any additional `data` key:value pairs will be added as query parameters even if they match a `path` array value.
+
 Since passing a parameter of the same name as an existing query parameter will replace the value, building an array property for a query requires MongoDB-style operators. If an array doesn’t already exist, the `$addToSet` operator will create it and add a value. Otherwise, it will simply add the value.
 
 `{ colors: { $addToSet: ‘blue’ } }`
@@ -92,11 +94,9 @@ To remove values from an existing array use the `$pull` operator:
 
 `{ colors: { $pull: ‘blue’ } }`
 
-For additional detail, you can examine the code comments in the `url` module [`index.js` file](https://github.com/apostrophecms/apostrophe/blob/main/modules/%40apostrophecms/url/index.js).
-
 ### `| clonePermanent`
 
-Given JavaScript data, this filter recursively strips out any properties whose names begin with a `_`, except `_id`. This is used to avoid pushing large documents into the DOM, keeping markup size down. This filter is usually followed by either the `json` or `jsonAttribute` filters.
+Given JavaScript data, this filter recursively strips out any properties whose names begin with a `_`, except `_id`. This is used to avoid pushing large related documents into the DOM, keeping markup size down. This filter is usually followed by either the `json` or `jsonAttribute` filters.
 ### `| css`
 Converts a string from other formats, such as underscore or camelCase to a kebab-case CSS identifier. For instance, `fooBar` becomes `foo-bar`.
 ### `| date(format)`

--- a/docs/guide/template-filters.md
+++ b/docs/guide/template-filters.md
@@ -1,6 +1,7 @@
 # Template filters
 
 ## Nunjucks supplied filters
+
 The Nunjucks templating language comes with several [built-in filters](https://mozilla.github.io/nunjucks/templating.html#filters). These filters apply functions to template data before outputting content to the page. They are called with a pipe operator `|` and can take arguments.
 
 <AposCodeBlock>
@@ -8,7 +9,6 @@ The Nunjucks templating language comes with several [built-in filters](https://m
 <h1>{{ data.page.headline | replace("foo", "bar" ) | upper }}</h1>
 ```
 </AposCodeBlock>
-
 
 In this example, a hypothetical page headline will be retrieved from the page data and then piped to the 'replace' filter, along with two arguments. This filter will scan the incoming data and replace any instances of ‘foo’ with 'bar'. The output of this filter will then pass the result to the upper function, which will return the input as an uppercase string before being output to the page.
 
@@ -30,7 +30,6 @@ By way of example, we'll create a link where the URL is included as part of the 
 
 <AposCodeBlock>
 ```javascript
-// lib/modules/link-widgets/index.js
 module.exports = {
   extend: '@apostrophecms/widget-type',
   options: {
@@ -70,6 +69,9 @@ module.exports = {
   }
 };
 ```
+<template v-slot:caption>
+  lib/modules/link-widgets/index.js
+</template>
 </AposCodeBlock>
 
 Within the `methods`, we create a function `stripHttp()` that takes a string from the template. It performs a RegExp replace to strip the protocol before returning the string.
@@ -79,15 +81,18 @@ In `init()`, we pass our function to the template module using `self.apos.templa
 To use this new filter you would simply pipe your data to the filter from within the template.
 
 <AposCodeBlock>
-```django
-{# lib/modules/link-widgets/views/widget.html #}
-<section data-link-widget>
-  <a href="{{ data.widget.url }}">{{ data.widget.label }}: {{ data.widget.url | stripHttp }}</a>
-</section>
-```
+  ```django
+  <section data-link-widget>
+    <a href="{{ data.widget.url }}">{{ data.widget.label }}: {{ data.widget.url | stripHttp }}</a>
+  </section>
+  ```
+  <template v-slot:caption>
+    lib/modules/link-widgets/views/widget.html
+  </template>
 </AposCodeBlock>
 
 ## Alphabetical Apostrophe filter reference
+
 ### `| build(url, path, data...)`
 
 This filter can add path and query string parameters to the passed URL. This is very useful for adding filters to the current URL, respecting other filters already present, without complicated logic.
@@ -110,15 +115,19 @@ To remove values from an existing array use the `$pull` operator:
 ### `| clonePermanent`
 
 Given JavaScript data, this filter recursively strips out any properties whose names begin with a `_`, except `_id`. This is used to avoid pushing large related documents into the DOM, keeping markup size down. This filter is usually followed by either the `json` or `jsonAttribute` filters.
+
 ### `| css`
 
 Converts a string from other formats, such as underscore or camelCase to a kebab-case CSS identifier. For instance, `fooBar` becomes `foo-bar`.
+
 ### `| date(format)`
 
 Turns a JavaScript Date object into a string, as specified by `format`. For formatting options, see the documentation of the `dayjs` npm module.
+
 ### `| json`
 
 Turns JavaScript data into a JSON string, **correctly escaped for safe use inside a** `script` **tag in the middle of an HTML document.** Note that it is **not** safe to use the Nunjucks `dump` filter in this way. This filter is not for attributes; see `jsonAttribute`.
+
 ### `| jsonAttribute(options)`
 
 Given JavaScript data, this filter escapes it correctly to be the value of a `data-` attribute of an element in the page. It does not add the `"` quote characters around the attribute itself, but it does escape any `"` characters in the JSON string.
@@ -130,12 +139,15 @@ Given JavaScript data, this filter escapes it correctly to be the value of a `da
 ### `| merge(object2, object3...)`
 
 When applied to an object, this filter "merges in" the properties of any additional objects given to it as arguments. Note that this is not a recursive merge. If two objects contain the same property, the last object wins.
+
 ### `| nlbr`
 
 Converts newlines found in a string into `<br />` tags. The incoming string is escaped from any HTML markup. After converting the newlines into breaks, the string is passed through the `|safe` filter before returning it.
+
 ### `| nlp`
 
 Breaks a string into `<p>...</p>` elements, based on newlines. Like the `| nlbr` filter, the incoming string is escaped and passed back as safe.
+
 ### `| query`
 
 Turns an object into a query string. This filter uses the stringify method of the npm (‘qs’ package)[https://www.npmjs.com/package/qs]. See also `build`.

--- a/docs/guide/templating.md
+++ b/docs/guide/templating.md
@@ -1,4 +1,4 @@
-# Working with Templates
+# Working with templates
 
 Templates are where code and content turn into web pages people can actually see and use. Apostrophe templates use the Nunjucks templating language and generally look like normal HTML markup with special tags and variables sprinkled throughout to render data.
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR adds an additional page to the Guide within the 'Templating' section documenting the use of Nunjucks filters. This includes a link out to the documentation for Nunjucks-supplied filters, a brief overview and detailed list of Apostrophe-supplied filters, and details on how to add a custom filter with code example.
Closes PRO-961.

## What are the specific steps to test this change?
1. Build and run the documentation
2. Navigate to Guide->Templating->Template Filters


*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
