### PR TITLE
Pro 3079 api options

### DIFF
--- a/docs/reference/api/pages.md
+++ b/docs/reference/api/pages.md
@@ -217,6 +217,7 @@ Individual page objects will include `_children` and `_ancestor` arrays, as well
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
 ::: note
 Query parameters will override the locale and mode present in the `_id`. So, if the `aposLocale=es` parameter is supplied, a `GET` request to the `_id` `###:en:published` will return the Spanish, not English, locale.
+You can also elect to use the `aposDocId` instead of the `_id` and use the query parameters to pass in the locale and mode parameters found in the `_id`.
 :::
 ### Request example
 
@@ -309,7 +310,7 @@ const data = {
   _position: 'lastChild'
 };
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=fr', {
+const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr:fr:published?apikey=myapikey', {
   method: 'PUT',
   headers: {
     'Content-Type': 'application/json'
@@ -405,7 +406,7 @@ This API route **Permanently deletes the page database document**. Moving pieces
 
 ```javascript
 // Request inside an async function.
-await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=en', {
+await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
   method: 'DELETE'
 });
 ```
@@ -479,7 +480,7 @@ The `body` of the request is ignored.
 
 ```javascript
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckhdscx5900054z9k88uqs16w/publish?apikey=myapikey&aposLocale=fr', {
+const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckhdscx5900054z9k88uqs16w:en:draft/publish?apikey=myapikey&aposLocale=fr', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json'

--- a/docs/reference/api/pages.md
+++ b/docs/reference/api/pages.md
@@ -42,8 +42,8 @@ All [page types](/reference/glossary.md#page) use a single set of API endpoints,
 |`all` | `?all=1` | Set to `1` to include the *entire* page tree, regardless of depth |
 |`flat` | `?flat=1` | Set to `1` to [return page results in an flat array](#flat-array-response) instead of the page tree structure |
 |`children` | `?children=false` | Set to `false` to exclude the `_children` array` |
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` to request the draft version of page documents instead of the current published versions. Set to `published` or leave it off to get the published version. Authentication is required to get drafts. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request page document versions for that locale. Defaults to the default locale. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` to request the draft version of page documents instead of the current published versions. Set to `published` or leave it off to get the published version. Authentication is required to get drafts. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to request page document versions for that locale. Defaults to the default locale. |
 <!-- TODO: link to docs about locales when available. -->
 
 ### Request example
@@ -209,9 +209,9 @@ Individual page objects will include `_children` and `_ancestor` arrays, as well
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to request a specific mode version of the page. Authentication is required to get drafts. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request the page document version for that locale. |
-|`render-areas` | `?render-areas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` or `published` to request a specific mode version of the page. Authentication is required to get drafts. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to request the page document version for that locale. |
+|`renderAreas` | `?renderAreas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
 
 <!-- TODO: link to docs about locales and modes when available. -->
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
@@ -220,7 +220,7 @@ Individual page objects will include `_children` and `_ancestor` arrays, as well
 
 ```javascript
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
+const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=en&renderAreas=true', {
   method: 'GET'
 });
 const document = await response.json();
@@ -245,8 +245,8 @@ The `_position` property uses specific string values rather than index numbers t
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` to insert a page as a draft instead of immediately published. Set to `published` or leave it off to insert a published page. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request page document versions for that locale. Defaults to the default locale. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` to insert a page as a draft instead of immediately published. Set to `published` or leave it off to insert a published page. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to request page document versions for that locale. Defaults to the default locale. |
 <!-- TODO: link to docs about locales when available. -->
 
 ### Request example
@@ -289,9 +289,9 @@ The `_position` property uses specific string values rather than index numbers t
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to replace a specific mode version of the page. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to replace the page document version for that locale. |
-|`render-areas` | `?render-areas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` or `published` to replace a specific mode version of the page. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to replace the page document version for that locale. |
+|`renderAreas` | `?renderAreas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
 
 <!-- TODO: link to docs about locales and modes when available. -->
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
@@ -307,7 +307,7 @@ const data = {
   _position: 'lastChild'
 };
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
+const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=fr', {
   method: 'PUT',
   headers: {
     'Content-Type': 'application/json'
@@ -327,8 +327,8 @@ The successful `PUT` request returns the newly created document. See the [page d
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to update a specific mode version of the page. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to update the page document version for that locale. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` or `published` to update a specific mode version of the page. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to update the page document version for that locale. |
 
 If moving a page within the page tree, the `PATCH`request must include *both* `_targetId` and `_position` as described in the [POST request description](#post-api-v1-apostrophecms-page).
 
@@ -346,7 +346,7 @@ const data = {
   title: 'Organization history'
 };
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
+const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=fr', {
   method: 'PATCH',
   headers: {
     'Content-Type': 'application/json'
@@ -393,8 +393,8 @@ This API route **Permanently deletes the page database document**. Moving pieces
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to delete a specific mode version of the piece. |
-|`apos-locale` | `?apos-locale=fr` | Set to [a valid locale](#TODO) to delete the piece document version for that locale. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` or `published` to delete a specific mode version of the piece. |
+|`aposLocale` | `?aposLocale=fr` | Set to [a valid locale](#TODO) to delete the piece document version for that locale. |
 
 <!-- TODO: link to docs about locales and modes when available. -->
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
@@ -403,7 +403,7 @@ This API route **Permanently deletes the page database document**. Moving pieces
 
 ```javascript
 // Request inside an async function.
-await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
+await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=en', {
   method: 'DELETE'
 });
 ```
@@ -470,14 +470,14 @@ The `body` of the request is ignored.
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-locale` | `?apos-locale=fr` | Identify a valid locale to publish the draft for that locale. Defaults to the locale of the `_id` in the request or the default locale. |
+|`aposLocale` | `?aposLocale=fr` | Identify a valid locale to publish the draft for that locale. Defaults to the locale of the `_id` in the request or the default locale. |
 <!-- TODO: link to docs about locales when available. -->
 
 ### Request example
 
 ```javascript
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckhdscx5900054z9k88uqs16w:en:draft/publish?apikey=myapikey', {
+const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckhdscx5900054z9k88uqs16w/publish?apikey=myapikey&aposLocale=fr', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json'

--- a/docs/reference/api/pages.md
+++ b/docs/reference/api/pages.md
@@ -215,12 +215,14 @@ Individual page objects will include `_children` and `_ancestor` arrays, as well
 
 <!-- TODO: link to docs about locales and modes when available. -->
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
-
+::: note
+Query parameters will override the locale and mode present in the `_id`. So, if the `aposLocale=es` parameter is supplied, a `GET` request to the `_id` `###:en:published` will return the Spanish, not English, locale.
+:::
 ### Request example
 
 ```javascript
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=en&renderAreas=true', {
+const response = await fetch('http://example.net/api/v1/@apostrophecms/page/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
   method: 'GET'
 });
 const document = await response.json();

--- a/docs/reference/api/pieces.md
+++ b/docs/reference/api/pieces.md
@@ -52,7 +52,7 @@ You may configure custom filters for a piece type as well. See [the guide on cus
 
 ```javascript
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/article?apikey=myapikey', {
+const response = await fetch('http://example.net/api/v1/article?apikey=myapikey&aposMode=draft', {
   method: 'GET'
 });
 const document = await response.json();

--- a/docs/reference/api/pieces.md
+++ b/docs/reference/api/pieces.md
@@ -38,9 +38,9 @@ Apostrophe provides built-in REST end points for all [piece types](/reference/gl
 |----------|------|-------------|
 |`page` | `?page=2` | The page of results to return |
 |`search` | `?search=shoes` | A search query to filter the response |
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` to request the draft version of piece documents instead of the current published versions. Set to `published` or leave it off to get the published version. Authentication is required to get drafts. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request piece document versions for that locale. Defaults to the default locale. |
-|`render-areas` | `?render-areas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` to request the draft version of piece documents instead of the current published versions. Set to `published` or leave it off to get the published version. Authentication is required to get drafts. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to request piece document versions for that locale. Defaults to the default locale. |
+|`renderAreas` | `?renderAreas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
 <!-- TODO: link to docs about locales when available. -->
 
 #### Custom filters
@@ -99,9 +99,9 @@ In case of an error an appropriate HTTP status code is returned.
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to request a specific mode version of the piece. Authentication is required to get drafts. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request the piece document version for that locale. |
-|`render-areas` | `?render-areas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` or `published` to request a specific mode version of the piece. Authentication is required to get drafts. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to request the piece document version for that locale. |
+|`renderAreas` | `?renderAreas=true` | Replaces area `items` data with a `_rendered` property set to a string of HTML based on widget templates. |
 
 <!-- TODO: link to docs about locales and modes when available. -->
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
@@ -110,7 +110,7 @@ In case of an error an appropriate HTTP status code is returned.
 
 ```javascript
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
+const response = await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=draft&aposLocale=en', {
   method: 'GET'
 });
 const document = await response.json();
@@ -126,8 +126,8 @@ The successful `GET` request returns the matching document. See the [piece docum
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` to insert a piece as a draft instead of immediately published. Set to `published` or leave it off to insert a published piece. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to request piece document versions for that locale. Defaults to the default locale. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` to insert a piece as a draft instead of immediately published. Set to `published` or leave it off to insert a published piece. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to request piece document versions for that locale. Defaults to the default locale. |
 <!-- TODO: link to docs about locales when available. -->
 
 ### Request example
@@ -156,8 +156,8 @@ The successful `POST` request returns the newly created document. See the [piece
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to replace a specific mode version of the piece. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to replace the piece document version for that locale. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` or `published` to replace a specific mode version of the piece. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to replace the piece document version for that locale. |
 
 <!-- TODO: link to docs about locales and modes when available. -->
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
@@ -168,7 +168,7 @@ The successful `POST` request returns the newly created document. See the [piece
 // Object with, at a minimum, properties for each required piece field.
 const data = { ... };
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
+const response = await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=fr', {
   method: 'PUT',
   headers: {
     'Content-Type': 'application/json'
@@ -188,8 +188,8 @@ The successful `PUT` request returns the newly created document. See the [piece 
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to update a specific mode version of the piece. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to update the piece document version for that locale. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` or `published` to update a specific mode version of the piece. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to update the piece document version for that locale. |
 
 If a `PATCH` operation is attempted in the published mode, the changes in the patch are applied to both the draft and the current document, but properties of the draft not mentioned in the patch are not published. This is to prevent unexpected outcomes.
 
@@ -205,7 +205,7 @@ const data = {
   category: 'Nerd Post'
 };
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
+const response = await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=en', {
   method: 'PATCH',
   headers: {
     'Content-Type': 'application/json'
@@ -244,8 +244,8 @@ This API route **permanently deletes the piece database document**. Moving piece
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-mode` | `?apos-mode=draft` | Set to `draft` or `published` to delete a specific mode version of the piece. |
-|`apos-locale` | `?apos-locale=fr` | Set to a valid locale to delete the piece document version for that locale. |
+|`aposMode` | `?aposMode=draft` | Set to `draft` or `published` to delete a specific mode version of the piece. |
+|`aposLocale` | `?aposLocale=fr` | Set to a valid locale to delete the piece document version for that locale. |
 
 <!-- TODO: link to docs about locales and modes when available. -->
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
@@ -254,7 +254,7 @@ This API route **permanently deletes the piece database document**. Moving piece
 
 ```javascript
 // Request inside an async function.
-await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
+await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=en', {
   method: 'DELETE'
 });
 ```
@@ -280,7 +280,7 @@ The `body` of the request is ignored.
 
 | Parameter | Example | Description |
 |----------|------|-------------|
-|`apos-locale` | `?apos-locale=fr` | Identify a valid locale to publish the draft for that locale. Defaults to the locale of the `_id` in the request or the default locale. |
+|`aposLocale` | `?aposLocale=fr` | Identify a valid locale to publish the draft for that locale. Defaults to the locale of the `_id` in the request or the default locale. |
 <!-- TODO: link to docs about locales when available. -->
 
 ### Request example

--- a/docs/reference/api/pieces.md
+++ b/docs/reference/api/pieces.md
@@ -107,6 +107,7 @@ In case of an error an appropriate HTTP status code is returned.
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
 ::: note
 Query parameters will override the locale and mode present in the `_id`. So, if the `aposLocale=es` parameter is supplied, a `GET` request to the `_id` `###:en:published` will return the Spanish, not English, locale.
+You can also elect to use the `aposDocId` instead of the `_id` and use the query parameters to pass in the locale and mode parameters found in the `_id`.
 :::
 
 ### Request example
@@ -171,7 +172,7 @@ The successful `POST` request returns the newly created document. See the [piece
 // Object with, at a minimum, properties for each required piece field.
 const data = { ... };
 // Request inside an async function.
-const response = await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=fr', {
+const response = await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr:fr:published?apikey=myapikey', {
   method: 'PUT',
   headers: {
     'Content-Type': 'application/json'
@@ -257,7 +258,7 @@ This API route **permanently deletes the piece database document**. Moving piece
 
 ```javascript
 // Request inside an async function.
-await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr?apikey=myapikey&aposMode=published&aposLocale=en', {
+await fetch('http://example.net/api/v1/article/ckitdo5oq004pu69kr6oxo6fr:en:published?apikey=myapikey', {
   method: 'DELETE'
 });
 ```

--- a/docs/reference/api/pieces.md
+++ b/docs/reference/api/pieces.md
@@ -105,6 +105,9 @@ In case of an error an appropriate HTTP status code is returned.
 
 <!-- TODO: link to docs about locales and modes when available. -->
 <!-- Read more about [mode and locale parameters on single-document requests](/guide/rest-apis#locale-and-mode-in-single-document-requests). -->
+::: note
+Query parameters will override the locale and mode present in the `_id`. So, if the `aposLocale=es` parameter is supplied, a `GET` request to the `_id` `###:en:published` will return the Spanish, not English, locale.
+:::
 
 ### Request example
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
The reference docs for the API incorrectly had the query parameters as kebab-case, rather than camelCase. This PR corrects this. It also changes the example usage to reflect adding parameter queries rather than altering the passed id. Closes PRO-3097

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

1. Build the documentation
2. Navigate to either `reference/api/pieces.html` or `/reference/api/pages.html`
3. Confirm that all of the query params are camelCase.
4. 
## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
