### PR TITLE
Pro 3213 add fileGroups documentation

### DIFF
--- a/docs/reference/field-types/attachment.md
+++ b/docs/reference/field-types/attachment.md
@@ -30,7 +30,7 @@ resume: {
 
 |  Property | Type   | Default | Description |
 |-----------|-----------|-----------|-----------|
-|`fileGroup` | String | n/a | Can be set to `images` or `office` to limit the file types that can be uploaded. See more below. |
+|`fileGroup` | String | n/a | Can be set to the default `images` or `office` groups, or a custom group, to limit the file types that can be uploaded. See more below. |
 |`help` | String | n/a | Help text for the content editor |
 |`htmlHelp` | String | n/a | Help text with support for HTML markup |
 |`if` | Object | `{}` | Conditions to meet before the field is active. [See the guide for details.](/guide/conditional-fields) | universal |
@@ -49,7 +49,7 @@ The uploaded files are stored in a web-accessible folder, however their file nam
 
 ## Custom file groups
 
-Developers can configure file type groups in addition to `office` and `image` using the `fileGroups` option of the `@apostrophecms/attachment` module. Those custom groups names can then be used for an attachment field's `fileGroup` setting.
+Developers can configure file type groups in addition to `office` and `image` using the `fileGroups` or `addFileGroups` options of the [`@apostrophecms/attachment` module](./../modules/asset.md). Those custom groups names can then be used for an attachment field's `fileGroup` setting.
 
 <!-- TODO: Link to the attachment module page for this instead once available. -->
 

--- a/docs/reference/field-types/attachment.md
+++ b/docs/reference/field-types/attachment.md
@@ -49,7 +49,7 @@ The uploaded files are stored in a web-accessible folder, however their file nam
 
 ## Custom file groups
 
-Developers can configure file type groups in addition to `office` and `image` using the `fileGroups` or `addFileGroups` options of the [`@apostrophecms/attachment` module](./../modules/asset.md). Those custom groups names can then be used for an attachment field's `fileGroup` setting.
+Developers can configure file type groups in addition to `office` and `image` using the `fileGroups` or `addFileGroups` options of the [`@apostrophecms/attachment` module](./../modules/attachment.md). Those custom groups names can then be used for an attachment field's `fileGroup` setting.
 
 <!-- TODO: Link to the attachment module page for this instead once available. -->
 

--- a/docs/reference/field-types/attachment.md
+++ b/docs/reference/field-types/attachment.md
@@ -49,7 +49,7 @@ The uploaded files are stored in a web-accessible folder, however their file nam
 
 ## Custom file groups
 
-Developers can configure file type groups in addition to `office` and `image` using the `fileGroups` or `addFileGroups` options of the [`@apostrophecms/attachment` module](./../modules/attachment.md). Those custom groups names can then be used for an attachment field's `fileGroup` setting.
+Developers can configure file type groups in addition to `office` and `image` using the `fileGroups` or `addFileGroups` options of the [`@apostrophecms/attachment` module](./../modules/attachment.md). Those custom group names can then be used for an attachment field's `fileGroup` setting.
 
 <!-- TODO: Link to the attachment module page for this instead once available. -->
 

--- a/docs/reference/modules/attachment.md
+++ b/docs/reference/modules/attachment.md
@@ -18,16 +18,18 @@ This reference is unusual compared to other reference pages in that it documents
 |  Property | Type | Description |
 |---|---|---|
 | [`fileGroups`](#filegroups) | Array | Assigns uploaded files to either an 'image' or 'office' category to allow for upload and manipulation. |
+| [`addFileGroups`](#addFileGroups) | Array | Allows addition of extension(s) to existing groups or creation of new groups. |
 
 ### `fileGroups`
 
-This option should be passed to the `@apostrophecms/attachment` module. By default, this option is set to an array with two objects and any array passed through this option will replace the default values.
+This option should be passed to the `@apostrophecms/attachment` module. By default, this option is set to an array with two objects and any array passed through this option will *replace* the default values.
 
 <AposCodeBlock>
 
 ```javascript
-...
-    self.fileGroups = self.options.fileGroups || [
+module.exports = {
+  options: {
+    fileGroups: [
       {
         name: 'images',
         label: 'apostrophe:images',
@@ -77,7 +79,80 @@ The first default object's `name` property is set to `images` and an `extensions
 Passing a new image extension type through replacement of the `@apostrophecms/attachment` default `fileGroups` option will not automatically cause the new image type to be re-sized or cropped, only added to the database and written to the designated uploadfs folder.
 :::
 
-The second default object is very similar, but for the `name` key it takes a value of `office`, and `image: false`, indicating that these file types can be attached to `@apostrophecms/file` pieces and should not be processed. Again, the `extensions` key takes an array of non-prefixed strings indicating the allowed file types. The `extensionMaps` maps alternative spellings to the specified extension.
+The second default object is very similar, but for the `name` key it takes a value of `office`, indicating that these file types can be attached to `@apostrophecms/file` pieces and should not be processed. Again, the `extensions` key takes an array of non-prefixed strings indicating the allowed file types. The `extensionMaps` maps alternative spellings to the specified extension.
+
+### `addFileGroups`
+
+This option should be passed to the `@apostrophecms/attachment` moduleand it takes an array of objects. Unlike the `fileGroups` option, this option is used to add to, not replace, the existing default extension groups. 
+
+A new extension can be added to the existing groups, either `office` or `image` by setting the object `name` property to the same value as the group you want to add the extension into.
+
+### Example
+
+<AposCodeBlock>
+
+```javascript
+module.exports= {
+  options: {
+    addFileGroups: [
+      // adds tif extension to the 'images' group
+      {
+        name: 'images',
+        extensions: [
+          'tif'
+        ],
+        extensionMaps: {
+          tiff: 'tif'
+        }
+      }
+    ]
+  }
+};
+```
+
+<template v-slot:caption>
+  modules/@apostrophecms/attachment/index.js
+</template>
+
+</AposCodeBlock>
+
+In addition to `name`, the object can have both `extensions` and `extensionMaps` properties that take values just like the properties in the `fileGroups` options. Both are optional, you only are required to supply one, but can supply both.
+
+The `addFileGroups` option can also be used to add a new grouping without eliminating the existing groups. This is accomplished through the addition of a new object containing `name`, `label`, `extensions` and `extensionMaps` properties. All are required.
+
+### Example
+
+<AposCodeBlock>
+
+```javascript
+module.exports= {
+  options: {
+    addFileGroups: [
+      {
+        name: 'logfiles',
+        extensions: [
+          'etl',
+          'evt',
+          'evtx'
+        ],
+        extensionMaps: {}
+      }
+    ]
+  }
+};
+```
+
+<template v-slot:caption>
+  modules/@apostrophecms/attachment/index.js
+</template>
+
+</AposCodeBlock>
+
+This example will make a new group, `logfiles`, but leave the `images` and `office` groups unaltered. This new group will be available to use in the `attachment` field `fileGroup` setting.
+
+::: note
+A single `addFileGroups` option can be used to both alter existing groups and add new groups by passing multiple objects in the array.
+:::
 
 ## Configuration
 

--- a/docs/reference/modules/attachment.md
+++ b/docs/reference/modules/attachment.md
@@ -238,10 +238,10 @@ The `options` parameter is optional. If `options.permissions` is explicitly set 
 ### `crop(req, _id, crop)`
 This method takes the image specified by the `_id` of an existing attachment, copies it to the uploadfs specified temporary location, applies the crop, and then saves it back into uploadfs storage. The `crop` parameter takes an object with `top`, `left`, `width`, and `height` properties. The passed values should be unitless, but must be JavaScript numbers, not strings.
 
-### `addFieldGroup(group)`
-This method takes an object specifying either a new file group or that extends an existing group. For new file groups the object should have `name`, `extensions`, and `extensionMaps` properties that are set-up like the objects passed through array to the `fieldGroups` option of this module.
+### `addFileGroup(group)`
+This method takes an object specifying either a new file group or that extends an existing group. For new file groups the object should have `name`, `extensions`, and `extensionMaps` properties that are set-up like the objects passed through array to the `fileGroups` option of this module.
 
-To extend an existing file group the object should have a `name` property matching the `name` value of an existing file group (`office` or `images`, by default). The object should also have an `extensions` property, `extensionMaps` property, or both. These properties are structured like the properties of the same name in the `fieldGroups` objects.
+To extend an existing file group the object should have a `name` property matching the `name` value of an existing file group (`office` or `images`, by default). The object should also have an `extensions` property, `extensionMaps` property, or both. These properties are structured like the properties of the same name in the `fileGroups` objects.
 
 
 ## Template helpers

--- a/docs/reference/modules/attachment.md
+++ b/docs/reference/modules/attachment.md
@@ -83,7 +83,7 @@ The second default object is very similar, but for the `name` key it takes a val
 
 ### `addFileGroups`
 
-This option should be passed to the `@apostrophecms/attachment` moduleand it takes an array of objects. Unlike the `fileGroups` option, this option is used to add to, not replace, the existing default extension groups. 
+This option should be passed to the `@apostrophecms/attachment` module and it takes an array of objects. This option allows you to specify new `fileGroups` containing allowed extensions for use in the `attachment` schema field. Passing this option an object with the same `name` property as an existing file group will merge the `extensions` and `extensionMaps` with the existing group.
 
 A new extension can be added to the existing groups, either `office` or `image` by setting the object `name` property to the same value as the group you want to add the extension into.
 
@@ -125,7 +125,7 @@ The `addFileGroups` option can also be used to add a new grouping without elimin
 <AposCodeBlock>
 
 ```javascript
-module.exports= {
+module.exports = {
   options: {
     addFileGroups: [
       {
@@ -237,6 +237,12 @@ The `options` parameter is optional. If `options.permissions` is explicitly set 
 
 ### `crop(req, _id, crop)`
 This method takes the image specified by the `_id` of an existing attachment, copies it to the uploadfs specified temporary location, applies the crop, and then saves it back into uploadfs storage. The `crop` parameter takes an object with `top`, `left`, `width`, and `height` properties. The passed values should be unitless, but must be JavaScript numbers, not strings.
+
+### `addFieldGroup(group)`
+This method takes an object specifying either a new file group or that extends an existing group. For new file groups the object should have `name`, `extensions`, and `extensionMaps` properties that are set-up like the objects passed through array to the `fieldGroups` option of this module.
+
+To extend an existing file group the object should have a `name` property matching the `name` value of an existing file group (`office` or `images`, by default). The object should also have an `extensions` property, `extensionMaps` property, or both. These properties are structured like the properties of the same name in the `fieldGroups` objects.
+
 
 ## Template helpers
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR adds documentation for the new `addFileGroups` option of the `attachment` module. Closes PRO-3213.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

1. Build the documentation.
2. Navigate to '/reference/modules/attachment.html' and '/reference/field-types/attachment.html'

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Will not be deployed until the release of the `attachment` module update.