### PR TITLE
document superscript and subscript toolbar options (valid once PRO-3504 is merged and published)

### DIFF
--- a/docs/guide/core-widgets.md
+++ b/docs/guide/core-widgets.md
@@ -47,6 +47,8 @@ To add formatting tools to the rich text toolbar, add their names to the `toolba
 | `'bold'` | Bold text |
 | `'italic'` | Italicize text |
 | `'strike'` | Strikethrough text |
+| `'superscript'` | Superscript text |
+| `'subscript'` | Subscript text |
 | `'link'` | Add a link |
 | `'anchor'` | Add an anchor id |
 | `'horizontalRule'` | Add a visual horizontal rule |


### PR DESCRIPTION
Can be tested now with the `pro-3504` branches of apostrophe and of testbed.