### PR TITLE
Adds initialModal option to reference

### DIFF
--- a/docs/reference/modules/widget-type.md
+++ b/docs/reference/modules/widget-type.md
@@ -24,6 +24,7 @@ These are options to *the module itself*, so they apply to *every* instance of t
 | [`defaultData`](#defaultdata) | Any | Default value of a contextual widget. |
 | [`deferred`](#deferred) | Boolean | This widget type should load last. |
 | [`icon`](#icon) | String | Icon name. |
+| [`initialModal`](#initialmodal) | Boolean | Determine whether to display modal when added to page. |
 | [`label`](#label) | String | Identifies this widget in a list of widget types. |
 | [`neverLoad`](#neverload) | Array | Widget types never loaded recursively by this widget. |
 | [`neverLoadSelf`](#neverloadself) | Boolean | The widget should never recursively load itself. |
@@ -72,6 +73,10 @@ Widget types may contain `relationship` and `relationshipReverse` fields that lo
 ### `icon`
 
 The name of the icon to be displayed for this widget type in a menu of widget types. This icon name must correspond to an icon loaded via [the `icons` module section](/reference/module-api/module-overview.md#icons). If not configured the widget type is listed without an icon.
+
+### `initialModal`
+
+The `initialModal` option is set to `true` by default. If set to `false`, it will prevent the initial modal from opening when a widget is added to the area.
 
 ### `label`
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR is just to beaten up the docs by adding the `initialModal` option to the `widget-type` reference page. Closes PRO-3572

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. Build the documentation
2. Navigate to `/reference/modules/widget-type.html#options`

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
