### PR TITLE
fix quotes in options

### DIFF
--- a/docs/reference/field-types/checkboxes.md
+++ b/docs/reference/field-types/checkboxes.md
@@ -47,7 +47,7 @@ genres: {
 |`required` | Boolean | `false` | If `true`, the field is mandatory |
 |`readOnly` | Boolean | `false` | If `true`, prevents the user from editing the field value |
 | `style` | String | n/a | If 'combo', adds a selection choices box and dropdown list of choices |
-| 'all' | Object | n/a | If `style: 'combo'`, adds a choice to select every option with a label set by the `label` property |
+| `all` | Object | n/a | If `style: 'combo'`, adds a choice to select every option with a label set by the `label` property |
 
 <!-- TODO: The following settings are likely to return, but are not yet implemented. -->
 <!-- |contextual | Boolean | false | If `true`, it will prevent the field from appearing in the editor modal | -->


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
In the previous PR to add the new combobox style options into the references section, the `all` option was surrounded by single tick quotes rather than backticks. This PR corrects this to conform to the style of this section.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. Build the documentation
2. Navigate to '/reference/field-types/checkboxes.html#optional'
## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
