### PR TITLE
note on where you can use database queries

### DIFF
--- a/docs/guide/database-queries.md
+++ b/docs/guide/database-queries.md
@@ -352,7 +352,7 @@ Using `self.apos.doc.find` has limitations, however. Significantly, pieces will 
 ## Where in my code can I make database queries?
 
 You can make database queries in async components (as shown above), routes
-(such as in an `apiRoutes` function), [server event handlers](./server-events.md),
+(such as in an [`apiRoutes`](../reference/module-api/module-overview.md#apiroutes-self) function), [server event handlers](./server-events.md),
 middleware and in pretty much any async function in your server-side code.
 However, you should avoid making database queries:
 


### PR DESCRIPTION
This is intended to cover a confusion our own team has experienced and that community members have as well, in addition to a very non-obvious point that came up yesterday about calling too early in the startup process.

I didn't really feel like there was a great place to link my reference to "api routes" to in the current docs. Did I miss a page?