### PR TITLE
fix: update Docker base image to node:24 and add Node.js version warning

### DIFF
--- a/docs/cookbook/using-docker.md
+++ b/docs/cookbook/using-docker.md
@@ -4,7 +4,12 @@
 
 The initial steps of this guide will assume that you will be hosting your database, project, and uploaded assets on the same server. The second part will outline steps for configuring to use the AWS S3 service for hosting assets. Finally, the third portion will provide guidance for using the MongoDB Atlas multi-cloud database.
 
+::: warning
+Avoid using the Node.js packages provided by your Linux distribution (e.g. via `apt` on Ubuntu/Debian), as these are often outdated and may not work correctly with ApostropheCMS. Always install Node.js directly from [nodejs.org](https://nodejs.org) or use a version manager like [nvm](https://github.com/nvm-sh/nvm).
+:::
+
 ## Creating the image
+
 ### Install Docker
 
 Docker can be installed on Mac, Windows, and Linux machines with either a CLI interface or using the Docker Desktop application, which acts as a graphical interface to the Docker engine. For this tutorial, we will use the CLI version. You can read more about Docker and install it on your machine by following the instructions in the Docker [docs](https://docs.docker.com/get-started/). Feel free to walk through the tutorials that you find there, but it isn't necessary before following this tutorial. We will cover any necessary terminology as we walk step-by-step through getting Apostrophe running. However, please verify that your Docker install works before continuing.
@@ -20,7 +25,7 @@ The [`Dockerfile`](https://docs.docker.com/engine/reference/builder/) passes a s
 <AposCodeBlock>
 
 ```bash
-FROM node:lts-alpine3.15
+FROM node:24
 
 WORKDIR /srv/www/apostrophe
 
@@ -38,13 +43,14 @@ RUN ./scripts/build-assets.sh
 
 CMD ["node", "app.js"]
 ```
+
 <template v-slot:caption>
   Dockerfile
 </template>
 
 </AposCodeBlock>
 
-Let's walk briefly through each of the lines. The first line specifies that this image will extend an existing image with the long-term support version of node.js running on an alpine linux v3.15 operating system. If you need another version of node, another version of Alpine Linux, or prefer not to use Alpine Linux as your container OS, you should alter this line to build from an official node.js [image](https://hub.docker.com/_/node/) or a 3<sup>rd</sup> party image.
+Let's walk briefly through each of the lines. The first line specifies that this image will extend the official Node.js 24 image. If you need a different version of Node.js, you should alter this line to build from an official Node.js [image](https://hub.docker.com/_/node/) or a 3<sup>rd</sup> party image.
 
 The `WORKDIR` command is used to define the working directory of the Docker container where all of the subsequent commands will be run. It implicitly runs both `mkdir` and `cd` commands.
 
@@ -53,7 +59,7 @@ By default, when we issue commands within the `Dockerfile` they are run within t
 We are now going to install all of our dependencies inside of the working directory. First, we copy the `package.json` and `package-lock.json` into our project. Next, we pass our `NODE_ENV=production` environment variable into the build and then add those dependencies using `RUN npm ci`.
 
 ::: info
-This means that you **must** commit the project `package-lock.json` and you must not list anything required to build the project assets as a "dev" dependency.  Your project doesn't need any of those in production, right? 
+This means that you **must** commit the project `package-lock.json` and you must not list anything required to build the project assets as a "dev" dependency. Your project doesn't need any of those in production, right?
 :::
 
 Following the dependency install, all of the necessary project files are copied into the container. Note that we will also create a `.dockerignore` file to exclude some files and folders from being copied.
@@ -89,6 +95,7 @@ We won't go through this file in detail. As covered in the previous section, it 
 Building the assets inside this script, which is part of a **build step** in the Dockerfile, ensures the assets become part of the image, so they don't have to be re-generated every time the image is used. The same is true for the `release-id` file, which Apostrophe uses to identify the asset bundle it should be using. It'll be the same bundle at build time and at run time. If the image is rebuilt, we'll get a new image, new CSS URLs, and no stale stylesheets.
 
 ### Creating a `.dockerignore` file
+
 The `.dockerignore` file prevents specific files from being copied into your final image. This is important to block sensitive or unnecessary files from being incorporated into your image. Simply go through your directory and copy any file or folder name not needed to build your project into your `.dockerignore` file. Note that folder names are followed by a `/`. I'm using Visual Studio Code in this tutorial, so the topmost folder listed won't be in your project if you use a different editor.
 
 <AposCodeBlock>
@@ -118,6 +125,7 @@ local.example.js
 </AposCodeBlock>
 
 ### Creating a `docker-compose.yaml` file
+
 In this guide, we are starting by creating multiple containers and a persistent volume. This is so that we can provide both a MongoDB instance and a place to store uploaded assets. We are going to do this using [Docker Compose](https://docs.docker.com/compose/) and a `docker-compose.yml` file. In the following sections of the tutorial, we will look at removing the extra container and volume by taking advantage of cloud storage and database services. Create this file at the root of your project.
 
 <AposCodeBlock>
@@ -141,7 +149,7 @@ services:
       - APOS_MONGODB_URI
       - APOS_CLUSTER_PROCESSES
     depends_on:
-      - db 
+      - db
     volumes:
       - /srv/www/apostrophe/public/uploads
 ```
@@ -152,7 +160,7 @@ services:
 
 </AposCodeBlock>
 
-The spacing in this file is very important. Whitespace, not tab, indentation indicates that a particular line is nested within the object passed on the line above it. Walking through this file, it starts with `services:`. From the indentation, we can see that we are creating two services - a `db:` container and a `web:` container.  Much like our `Dockerfile`, within the `db:` we start by specifying an image to run. In this case, it is the `mongo:4.4.14` official image for running MongoDB v4.4.14. Other images can be found in the docker library GitHub repo [README](https://github.com/docker-library/docs/blob/master/mongo/README.md#supported-tags-and-respective-dockerfile-links). You should use the version that mirrors your development environment.
+The spacing in this file is very important. Whitespace, not tab, indentation indicates that a particular line is nested within the object passed on the line above it. Walking through this file, it starts with `services:`. From the indentation, we can see that we are creating two services - a `db:` container and a `web:` container. Much like our `Dockerfile`, within the `db:` we start by specifying an image to run. In this case, it is the `mongo:4.4.14` official image for running MongoDB v4.4.14. Other images can be found in the docker library GitHub repo [README](https://github.com/docker-library/docs/blob/master/mongo/README.md#supported-tags-and-respective-dockerfile-links). You should use the version that mirrors your development environment.
 
 Next, we are specifying that the database should communicate over port `27018`. This is different from the port typically used in order to direct communication to the dockerized version and not a local MongoDB. If you need your database to communicate over a different port, you have to change it here and in your `.env` file.
 
@@ -171,6 +179,7 @@ The `depends_on:` key indicates that our Apostrophe instance requires the presen
 Finally, much like with the database, we are persisting a volume for any uploads to be written into. Without this, any uploads would be lost the next time we deployed.
 
 ### Creating the `.env` file
+
 The last file we need to create before bringing our project up is a `.env` file at the root of our project containing the environmental variables. In this example file, we are assuming that you are hosting on a single server. Therefore we are setting the `APOS_CLUSTER_PROCESSES` environment variable to `2` to ensure that there is availability in case of a restart due to a crash. This number could be increased depending on your server.
 
 <AposCodeBlock>
@@ -190,6 +199,7 @@ APOS_CLUSTER_PROCESSES=2
 The only other line that might need alteration is the `APOS_MONGODB_URI` if your database needs to listen on a different port.
 
 ### Spinning our project up
+
 Bringing our project up in Docker is a two-step process. First, from the CLI run `docker compose build`. This will create our project image. You should see commands from your `Dockerfile`, messages from the npm install, and then the familiar messages from Apostrophe as it builds the assets.
 
 When this finishes, you can run the command `docker compose up`. This will bring your project up and if you are using the defaults, allow you to access the site at `http://localhost:3000`. At this point, you won't be able to log in because it is a fresh database. To do this, you need to open a session with your container running Apostrophe. With both containers still running, give the following command from your terminal.
@@ -197,6 +207,7 @@ When this finishes, you can run the command `docker compose up`. This will bring
 ```bash
 docker exec -it <container_name> /bin/sh
 ```
+
 The `<container_name>` should be substituted with the name you gave your container in the `docker-compose.yaml` file.
 
 When the connection to your container is established, you issue the normal command for adding an Apostrophe admin to the database.
@@ -214,6 +225,7 @@ docker compose down
 ```
 
 ### Updating your project
+
 Whenever your code or dependencies change, for example, when there is an update to Apostrophe, your container will have to be rebuilt. This can be done using the same steps as the initial build.
 
 First, make sure your `package-lock.json` file is up to date by running `npm update` on your project repo. Then run:
@@ -229,14 +241,17 @@ docker compose restart
 ```
 
 ### Summary
+
 While in this example, our project is still being hosted locally, any of these commands can be issued on a server that supports Docker once your project is deployed.
 
 Right now, our Dockerized container is limited to a single server. For simple, low-traffic sites this could be fine. However, if we want to scale our site over several servers and add a load balancer like Nginix, we need to add support for cloud storage and a cloud database. Fortunately, Apostrophe makes this relatively easy.
 
 ## Using AWS S3 services
+
 If you aren't hosting your project on a single server, you will need to have a different uploaded asset storage method. Typically this is a service like Amazon Web Services S3 or another similar service. Apostrophe is set up to easily use S3 services by adding environment variables. You can read more in the [documentation](/reference/modules/uploadfs.md#s3-storage-options). We can take advantage of this in Docker by expanding our `docker-compose.yml` and `.env` files.
 
 ### Changing the `docker-compose.yaml` file
+
 In order to pass the environment variables into our project container we just need to add them inside the `environment:` key. If we are using S3 services at Amazon, we need to add four variables: `APOS_S3_REGION`, `APOS_S3_BUCKET`, `APOS_S3_KEY`, and `APOS_S3_SECRET`. For other S3-type storage solutions, such as [filebase](https://filebase.com/), you will also want to set the `APOS_S3_ENDPOINT` variable. For AWS, your `environment:` section should now look like this:
 
 <AposCodeBlock>
@@ -261,6 +276,7 @@ In order to pass the environment variables into our project container we just ne
 </AposCodeBlock>
 
 ### Changing the `.env` file
+
 Next, the `.env` file should be modified to contain values for each of the new environment variables. Each will get populated with values specific to your S3 buckets. Again, add the `APOS_S3_ENDPOINT` with value if using a service not hosted by AWS.
 
 <AposCodeBlock>
@@ -281,34 +297,39 @@ APOS_S3_SECRET=<account secret>
 </AposCodeBlock>
 
 ### Finishing up
+
 While our Docker container is now configured for storing items on AWS S3, it won't fully work if we were to spin it up now. First, we have to configure our S3 bucket to allow the public to access it. This is easily done through the AWS control panel.
 
-1) First, select the bucket from the S3 management console and then click on the "Permissions" tab. Click on the "Edit" button to edit your permissions.
-![S3 console permissions tab](../images/s3-permissions-tab.png)
+1. First, select the bucket from the S3 management console and then click on the "Permissions" tab. Click on the "Edit" button to edit your permissions.
+   ![S3 console permissions tab](../images/s3-permissions-tab.png)
 
-2) Uncheck the "Block all public access" box and save the changes. You will have to confirm that you want to do this.
-![S3 console showing all public access blocks for S3 bucket turned off](../images/s3-public-permissions.png)
+2. Uncheck the "Block all public access" box and save the changes. You will have to confirm that you want to do this.
+   ![S3 console showing all public access blocks for S3 bucket turned off](../images/s3-public-permissions.png)
 
-3) Scroll down the page to the "Object Ownership" section and click the "Edit" button.
-![The S3 console Object Ownership section](../images/s3-object-ownership.png)
+3. Scroll down the page to the "Object Ownership" section and click the "Edit" button.
+   ![The S3 console Object Ownership section](../images/s3-object-ownership.png)
 
-4) Select "ACLs enabled" and "Object writer" then acknowledge the warning and save the changes.
-![S3 console object ownership edit screen](../images/s3-object-permission.png)
+4. Select "ACLs enabled" and "Object writer" then acknowledge the warning and save the changes.
+   ![S3 console object ownership edit screen](../images/s3-object-permission.png)
 
 Just like with the Docker container previously, you can now bring the site up with:
 
 ```sh
 docker compose up
 ```
+
 Any assets uploaded through the site will now be stored in your S3 bucket rather than on the server directly.
 
 ## Using MongoDB Atlas
+
 [MongoDB Atlas](https://www.mongodb.com/atlas/database) is a robust, multi-cloud database service. There are a number of advantages, but one is that using a cloud database means that our project can run on multiple servers but still all access the same database. If we run our project in a docker container without an accompanying database container, we don't have to use Docker Compose. However, since we have already built these assets, we can continue with these files. Two files must be altered - `docker-compose.yaml` and `.env`.
 
 ### Changing the `docker-compose.yaml` file
+
 Since we no longer have to use the database container, we can simply delete that whole section from the `services:`. Likewise, we can also remove the `depends_on:` section since we no longer have that container.
 
 ### Changing the `.env` file
+
 First, start by getting an account and setting up a project and cluster according to the [instructions](https://www.mongodb.com/docs/atlas/?_ga=2.115258319.959071482.1662986164-305956368.1655805952&_gac=1.50376795.1662898658.Cj0KCQjwjvaYBhDlARIsAO8PkE2KG3UP3yszcTYrzDpB8BRxDZ7vM2vLMafvX59emZZKkDExo_ZPZRIaAneGEALw_wcB) at the Atlas site. Once you do this, you can get the connect string for your database. The `APOS_MONGODB_URI` was already being set within the `.env` file. You simply need to substitute your connect string for the value.
 
 ::: info
@@ -316,9 +337,11 @@ Any special characters in your user name or password within the connection strin
 :::
 
 ### Finishing up
+
 Since this will create a new database, once you bring your site up you should add an admin user as was [detailed](#spinning-our-project-up) when we used the containerized version.
 
 Then, to bring the site up use :
+
 ```sh
 docker compose up
 ```
@@ -327,8 +350,8 @@ docker compose up
 
 Great, so we have a working Apostrophe Docker image. How do we get it on the web? There are many options. Here are a few.
 
-* [Automated builds from GitHub](https://docs.docker.com/docker-hub/github/)
-* Install [Dokku](https://dokku.com/docs/getting-started/installation/) on the server then use [Dockerfile deployment](https://dokku.com/docs/getting-started/install/docker/)
-* Use `docker save` and `docker load` to [deploy without a private registry](https://realguess.net/2015/02/04/docker-save-load-and-deploy/)
-* Build the image directly on the server
-* Many more (use a web search!)
+- [Automated builds from GitHub](https://docs.docker.com/docker-hub/github/)
+- Install [Dokku](https://dokku.com/docs/getting-started/installation/) on the server then use [Dockerfile deployment](https://dokku.com/docs/getting-started/install/docker/)
+- Use `docker save` and `docker load` to [deploy without a private registry](https://realguess.net/2015/02/04/docker-save-load-and-deploy/)
+- Build the image directly on the server
+- Many more (use a web search!)


### PR DESCRIPTION
Updated the example Dockerfile to use node:24 instead of node:lts-alpine3.15. Added a warning advising users to avoid OS-provided Node.js packages, which are often outdated. Refs apostrophecms/apostrophe#4645

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:
*Check one*

- [x] main

- [ ] Check if this PR will be resubmitted against another branch
## Summary

Updated the example Dockerfile to use `node:24` instead of `node:lts-alpine3.15`. Added a warning advising users to avoid OS-provided Node.js packages, which are often outdated and may not work correctly with ApostropheCMS. Refs apostrophecms/apostrophe#4645

## What are the specific steps to test this change?

1. Navigate to the Docker hosting cookbook page
2. Confirm the Dockerfile example shows `node:24`
3. Confirm the warning block appears before the "Creating the image" section

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Documentation

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [x] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Change suggested by @boutell in apostrophecms/apostrophe#4645
Note: separate PRs to update the `engines` field in `package.json` to `node >= 22` are planned for `starter-kit-essentials`, `public-demo`, and `apollo`.